### PR TITLE
Fixed TVAULT-2757

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/ensure_data_dirs.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/ensure_data_dirs.yml
@@ -1,5 +1,5 @@
 - name: ensure that {{TVAULT_DATA_DIR}} is present
-  file: name="{{TVAULT_DATA_DIR}}" state=directory
+  file: name="{{TVAULT_DATA_DIR}}" owner={{TVAULT_CONTEGO_EXT_USER}} group={{TVAULT_CONTEGO_EXT_GROUP}} state=directory recurse=yes
 
 - name: ensure that {{TVAULT_DATA_DIR_OLD}} is removed
   file: name="{{TVAULT_DATA_DIR_OLD}}" state=absent

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/set_virtenv.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/set_virtenv.yml
@@ -103,7 +103,7 @@
     - name: activate the virtual environment and set cryptography symlinks when openstack_release is newton
       shell: '{{virtenv_premitaka_script_path}}'
       register: tvault_contego_version_installed
-  when: OPEN_STACK_RELEASE == premitaka
+  when: OPEN_STACK_RELEASE == premitaka or OPEN_STACK_RELEASE == queens
 
 - block:
     - name: copy set_virtenv_newton.sh to destination host


### PR DESCRIPTION
TVAULT-2757:
**Issue** : tvault-contego pip package in not getting download and installed as ansible-template to download pip package and install it inside virtual env. is not getting called for queens setup.
**Fix**: added code so that ansible-template to download and install pip pakcage sholud get called for queens openstack release as well.

TVAULT-2750:  
**Fix**: added  code to provide nova user permissions to "/var/trliovault-mounts" dir.
@shyam-biradar , @abhijeetpatra , @MuralidharB , @rajneeshkapoor , @sachin-trilio Please review
