### PR TITLE
Fixed TVAULT-2676 and added ignore_errors to fix easy_install issue

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/install.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/install.yml
@@ -8,7 +8,7 @@
        
 - name: install pip if it is not installed 
   shell: easy_install --no-deps http://{{IP_ADDRESS}}:{{PORT_NO}}/packages/pip-{{pip_version}}.tar.gz 
-  register: pip_installation
+  ignore_errors: yes
   when: "'No module' in pip_version1.stderr or 'pip' in pip_version1.stdout"
 
 - name: grep tvault-contego version using CURL call

--- a/ansible/roles/ansible-horizon-plugin/tasks/uninstall.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/uninstall.yml
@@ -20,7 +20,8 @@
 
 - name: ensure that pip of version 7.1.2 is installed on controller
   easy_install: name="http://{{IP_ADDRESS}}:{{PORT_NO}}/packages/pip-{{pip_version}}.tar.gz" state=present
-
+  ignore_errors: yes
+ 
 - name: uninstall python-workloadmanager client 
   pip: name=python-workloadmgrclient state=absent 
  

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/contego_service.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/contego_service.yml
@@ -60,7 +60,8 @@
   block:
     - shell: systemctl daemon-reload
     - name: enable tvault-contego service and reload it
-      service: name=tvault-contego  state=started enabled=yes
+      service: name=tvault-contego  state=restarted enabled=yes
+      service: name=tvault-contego  state=restarted enabled=yes
   when: >
        (ansible_distribution_major_version=="7" and ansible_distribution== centos) or
        (ansible_distribution_major_version=="7" and ansible_distribution=="RedHat") or

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/validate_obj_bkp.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/validate_obj_bkp.yml
@@ -18,6 +18,7 @@
 - block:
     - name: Ensure python-pip is installed
       shell: easy_install --no-deps http://{{IP_ADDRESS}}:{{PORT_NO}}/packages/pip-{{pip_version}}.tar.gz 
+      ignore_errors: yes
 
     - name: Ensure python swift client is present
       pip: name="python-swiftclient" state=present


### PR DESCRIPTION
1. added code to restart contego service twice. as on first restart contego service is failing in sometime.
2. added code to fix easy_install command failure issue(TVAULT-2731) . We have release noted this issue. but we need some fix here to avoid ansible tasks failures. 

@abhijeetpatra , @shyam-biradar  , @rajneeshkapoor , @sachin-trilio , @MuralidharB  Please review.
 