### PR TITLE
Request access to nova database

### DIFF
--- a/juju-charms/charm-trilio-data-mover-api/src/reactive/dmapi_handlers.py
+++ b/juju-charms/charm-trilio-data-mover-api/src/reactive/dmapi_handlers.py
@@ -115,7 +115,8 @@ def setup_database(database):
     """On receiving database credentials, configure the database on the
     interface.
     """
-    database.configure('dmapi', 'dmapi', hookenv.unit_private_ip())
+    database.configure('nova', 'dmapi', prefix='nova')
+    database.configure('nova_api', 'dmapi', prefix='novaapi')
     dmapi.assess_status()
 
 


### PR DESCRIPTION
The DataMover API requires access to the nova database (not the dmapi
database).

Update handler to request access to the correct shared database and
drop provision of unit private address - the interface does the
right thing with regards to using network space binding of the
relation endpoint on the local charm unit.