### PR TITLE
accomodate all shell changes to ansible for 3.0

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/add_users.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/add_users.yml
@@ -1,6 +1,3 @@
-- name: Adding passwordless sudo access to nova user
-  lineinfile: "dest=/etc/sudoers.d/tvault-nova state=present create=yes line='nova ALL=(ALL) NOPASSWD: ALL'"
-
 - name: Adding nova user to system groups
   user: name={{TVAULT_CONTEGO_EXT_USER}} groups="{{item}}" state=present
   with_items:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/contego_service.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/contego_service.yml
@@ -39,15 +39,19 @@
      src: contego_service.j2
      dest: "{{contego_service_file_path}}"
   when: >
-        (ansible_distribution_major_version=="7" and ansible_distribution== centos) or
-        (ansible_distribution_major_version=="7" and ansible_distribution=="RedHat") or (ansible_distribution == SLES)
+        ((ansible_distribution_major_version=="7" and ansible_distribution== centos) or
+        (ansible_distribution_major_version=="7" and ansible_distribution=="RedHat") or (ansible_distribution == SLES) or
+        (ansible_distribution=="Ubuntu" and (ansible_lsb.codename == xenial or ansible_lsb.codename == willy))) and (NFS == True)
 
 - name: create tvault-contego-service-in-systemd if ansible_distribution is Ubuntu 16
   template:
-     src: contego_service.j2
+     src: contego_service_s3.j2
      dest: "{{contego_service_file_path}}"
-  when: ansible_distribution=="Ubuntu" and (ansible_lsb.codename == xenial or ansible_lsb.codename == willy)
-
+  when: >
+        ((ansible_distribution_major_version=="7" and ansible_distribution== centos) or
+        (ansible_distribution_major_version=="7" and ansible_distribution=="RedHat") or (ansible_distribution == SLES) or
+        (ansible_distribution=="Ubuntu" and (ansible_lsb.codename == xenial or ansible_lsb.codename == willy))) and (object_store == True)
+ 
 - name: create tvault-contego-service-in-systemd ansible_distribution is ubuntu 14
   template:
      src: contego_service_debian.j2
@@ -58,7 +62,7 @@
   block:
     - shell: systemctl daemon-reload
     - name: enable tvault-contego service and reload it
-      service: name=tvault-contego  state=started enabled=yes
+      service: name=tvault-contego  state=stopped enabled=yes
   when: >
        (ansible_distribution_major_version=="7" and ansible_distribution== centos) or
        (ansible_distribution_major_version=="7" and ansible_distribution=="RedHat") or

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/set_virtenv.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/set_virtenv.yml
@@ -42,8 +42,16 @@
   ignore_errors: yes
   when: TVAULT_CONTEGO_VERSION.stdout == tvault_contego_version_set
 
-- name: download virtual environment tar bundle from applainace
+- name: download virtual environment tar bundle from applainace if openstack release is newton and distribution is ubuntu
+  get_url: url="http://{{IP_ADDRESS}}:{{PORT_NO}}/packages/{{OPEN_STACK_RELEASE}}/ubuntu/tvault-contego-virtenv.tar.gz" dest="{{TVAULT_CONTEGO_VIRTENV}}"
+  when: (OPEN_STACK_RELEASE == newton) and (ansible_distribution == ubuntu)
+
+- debug: msg="print true if  virtual env dir exists:{{OPEN_STACK_RELEASE}}"
+- debug: msg="print true if  virtual env dir exists:{{ansible_distribution}}"
+
+- name: download virtual environment tar bundle from applainace if openstack distribution is not ubuntu
   get_url: url="http://{{IP_ADDRESS}}:{{PORT_NO}}/packages/{{OPEN_STACK_RELEASE}}/tvault-contego-virtenv.tar.gz" dest="{{TVAULT_CONTEGO_VIRTENV}}"
+  when: (OPEN_STACK_RELEASE != newton) or (ansible_distribution != ubuntu) 
 
 - name: remove existing .virtenv directory
   file: path={{TVAULT_CONTEGO_VIRTENV_PATH}} state=absent
@@ -65,7 +73,7 @@
             python -c "import cffi;print cffi.__path__[0]"
             python -c "import _cffi_backend;print _cffi_backend.__file__"
   register: cryptography
-  when: OPEN_STACK_RELEASE == newton
+  when: (OPEN_STACK_RELEASE == newton) and (ansible_distribution != ubuntu)
 
 - debug: msg="cryptography_path={{cryptography_mitaka}}"  verbosity={{verbosity_level}}
 - debug: msg="cryptography_path={{cryptography}}"  verbosity={{verbosity_level}}
@@ -120,17 +128,30 @@
   when: OPEN_STACK_RELEASE == premitaka
 
 - block:
-    - name: copy set_virtenv_newton.sh to destination host
+    - name: copy set_virtenv_newton.sh to destination host if opnestak is nweton and diestribution is redhat
       template:
          src: set_virt_newton.j2
          dest: "{{virtenv_newton_script_path}}"
-
+   
     - file: path="{{virtenv_newton_script_path}}" mode=765 
 
     - name: activate the virtual environment and set cryptography symlinks when openstack_release is newton
       shell: '{{virtenv_newton_script_path}}'
       register: tvault_contego_version_installed
-  when: OPEN_STACK_RELEASE == newton
+  when: OPEN_STACK_RELEASE == newton and (ansible_distribution != ubuntu)
+
+- block:
+    - name: copy set_virtenv_newton.sh to destination host if openstack is newton and distribution is ubuntu
+      template:
+         src: set_virt_newton_ubuntu.j2
+         dest: "{{virtenv_newton_script_path}}"
+
+    - file: path="{{virtenv_newton_script_path}}" mode=765
+
+    - name: activate the virtual environment and set cryptography symlinks when openstack_release is newton
+      shell: '{{virtenv_newton_script_path}}'
+      register: tvault_contego_version_installed
+  when: (OPEN_STACK_RELEASE == newton) and (ansible_distribution == ubuntu)
 
 - debug: msg="tvault_contego_version_installed:{{tvault_contego_version_installed}}" verbosity={{verbosity_level}}
 

--- a/ansible/roles/ansible-tvault-contego-extension/templates/contego_service.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/contego_service.j2
@@ -1,6 +1,5 @@
 [Unit]
 Description=Tvault contego
-After=openstack-nova-compute.service
 [Service]
 User={{TVAULT_CONTEGO_EXT_USER}}
 Group={{TVAULT_CONTEGO_EXT_USER}}
@@ -9,5 +8,6 @@ ExecStart={{TVAULT_CONTEGO_EXT_PYTHON}} {{TVAULT_CONTEGO_EXT_BIN}} {{CONFIG_FILE
 TimeoutStopSec=20
 KillMode=process
 Restart=on-failure
+CPUShares=2
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/ansible-tvault-contego-extension/templates/contego_service_s3.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/contego_service_s3.j2
@@ -1,13 +1,14 @@
 [Unit]
-Description=Tvault Object Store
-BindsTo=tvault-contego.service
+Description=Tvault contego
+Requires=tvault-object-store.service
 [Service]
 User={{TVAULT_CONTEGO_EXT_USER}}
 Group={{TVAULT_CONTEGO_EXT_USER}}
 Type=simple
-ExecStart={{TVAULT_CONTEGO_EXT_PYTHON}} {{TVAULT_CONTEGO_EXT_OBJECT_STORE}} --config-file={{TVAULT_CONTEGO_CONF}}
+ExecStart={{TVAULT_CONTEGO_EXT_PYTHON}} {{TVAULT_CONTEGO_EXT_BIN}} {{CONFIG_FILES}}
 TimeoutStopSec=20
 KillMode=process
 Restart=on-failure
+CPUShares=2
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/ansible-tvault-contego-extension/templates/set_virt_newton_ubuntu.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/set_virt_newton_ubuntu.j2
@@ -1,0 +1,7 @@
+#!/bin/bash 
+set -e
+cd {{TVAULT_CONTEGO_VIRTENV}}
+source .virtenv/bin/activate
+pip install http://{{IP_ADDRESS}}:{{PORT_NO}}/packages/tvault-contego-{{TVAULT_CONTEGO_VERSION.stdout}}.tar.gz
+pip list | grep tvault-contego | cut -d'(' -f2 | cut -d')' -f1
+rm -rf tvault-contego-virtenv.tar.gz


### PR DESCRIPTION
Fixed following issues:
1.TVAULT-2755: Removed code to create cpu.shares files at "/sys/fs/cgroup/trilio/cpu/" 
2.TVAULT-2687: i.Removed nova users root access from soudeors file 
                           ii. Created seperate service template for NFS and object-store 
3.TVAULT-2756: Removed "After=opesntack-nova-compute" paramter from contego file
4.TVAULT-2699: Addeed code to download "newton_ubuntu" virtual env           

@MuralidharB, @amitkumar-a4 , @shyam-biradar , @abhijeetpatra , @rajneeshkapoor , @sachin-trilio Please review            
