### PR TITLE
Fixed the trilio-horizon-plugin.html index template path

### DIFF
--- a/juju-charms/charm-trilio-horizon-plugin/src/reactive/trilio_horizon_plugin.py
+++ b/juju-charms/charm-trilio-horizon-plugin/src/reactive/trilio_horizon_plugin.py
@@ -51,7 +51,19 @@ def copy_template():
     """
     Copy TrilioVault Horizon HTML Template from files/trilio dir
     """
-    dashboard_path = '/usr/local/lib/python2.7/dist-packages/dashboards/'
+    # Find where the dashboard path is for the index to be replaced,
+    # or default to the first path if none found /usr/local/lib
+    dashboard_paths = ['/usr/local/lib/python2.7/dist-packages/dashboards/',
+                       '/usr/lib/python2.7/dist-packages/dashboards/']
+
+    dashboard_path = None
+    for path in dashboard_paths:
+        if os.path.isfile('{}/workloads_admin/templates/'
+                          'workloads_admin/index.html'.format(path)):
+            dashboard_path = path
+            break
+    if dashboard_path is None:
+        dashboard_path = dashboard_paths[0]
 
     # install and compress new dashboard if it's provided by user
     if os.path.isfile("files/trilio/trilio-horizon-plugin.html"):


### PR DESCRIPTION
It was determined that on some systems, the path to the workloads_admin
dashboards was /usr/local/lib and some others, /usr/lib, so this code
attempts to find the index.html file to be replaced and then sets the
dashboard_path for file replacement to that path, or reverts to original
setting.