### PR TITLE
TVAUT-3409

### DIFF
--- a/redhat-director-scripts/docker/services/trilio-datamover-api.yaml
+++ b/redhat-director-scripts/docker/services/trilio-datamover-api.yaml
@@ -38,10 +38,6 @@ parameters:
     default: '8784'
     description: Trilio Dmapi listen port
     type: string
-  DmApiEnableSSL:
-    default: true
-    description: Need to enable ssl for dmapi endpoints or not
-    type: boolean
   DmApiSslPort:
     default: '13784'
     description: Trilio Dmapi ssl listen port
@@ -54,7 +50,6 @@ outputs:
       service_name: trilio_datamover_api
       config_settings:
         trilio::dmapi::dmapi_port: {get_param: DmApiPort}
-        trilio::dmapi::dmapi_enable_ssl: {get_param: DmApiEnableSSL}
         trilio::dmapi::dmapi_ssl_port: {get_param: DmApiSslPort}
         tripleo::trilio_datamover_api::haproxy_endpoints:
             trilio_datamover_api:

--- a/redhat-director-scripts/puppet/trilio/manifests/dmapi.pp
+++ b/redhat-director-scripts/puppet/trilio/manifests/dmapi.pp
@@ -1,7 +1,7 @@
 class trilio::dmapi ( 
   $dmapi_port                      = '8784',
   $dmapi_ssl_port                  = '13784',
-  $dmapi_enable_ssl                = true,
+  $dmapi_enable_ssl                = false,
   $oslomsg_rpc_proto       	   = hiera('messaging_rpc_service_name', 'rabbit'),
   $oslomsg_rpc_hosts       	   = any2array(hiera('rabbitmq_node_names', undef)),
   $oslomsg_rpc_password    	   = hiera('nova::rabbit_password'),

--- a/redhat-director-scripts/puppet/trilio/templates/dmapi.erb
+++ b/redhat-director-scripts/puppet/trilio/templates/dmapi.erb
@@ -1,15 +1,9 @@
 [DEFAULT]
 dmapi_workers = 2
 transport_url = <%= @default_transport_url %>
-<% if @dmapi_enable_ssl == true %>
-dmapi_link_prefix = https://<%= @my_ip %>:<%= @dmapi_ssl_port %>
-dmapi_enabled_ssl_apis = dmapi
-dmapi_listen_port = <%= @dmapi_ssl_port %>
-<% else %> 
 dmapi_link_prefix = http://<%= @my_ip %>:<%= @dmapi_port %>
 dmapi_enabled_ssl_apis =
 dmapi_listen_port = <%= @dmapi_port %>
-<% end %>
 dmapi_enabled_apis = dmapi
 bindir = /usr/bin
 instance_name_template = instance-%08x

--- a/redhat-director-scripts/trilio_env.yaml
+++ b/redhat-director-scripts/trilio_env.yaml
@@ -14,17 +14,6 @@ parameter_defaults:
 
    DockerTrilioDmApiImage: 192.168.122.10:8787/trilio/trilio-datamover-api:3.1.58-queens
 
-   ## Datamover api port, default is 8784
-   DmApiPort: 8784
-
-   ## If user wants to enable SSL for datamover api's internal endpoint
-   ## Default value is 'false'.
-   DmApiEnableSSL: false
-
-   ## Dmapi service public interface port. It will get configured for dmapi 
-   ## haproxy frontend and dmapi public endpoint in keystone
-   DmApiSslPort: 13784
-
    ## Backup target type nfs/s3, used to store snapshots taken by triliovault
    BackupTargetType: 'nfs'
 


### PR DESCRIPTION
Removed DmapiEnableSSl, DmapiPort, DmapiSslPort variables from trilio_env.yaml
Removed support for internal ssl on dmapi. SSL on dmapi will be handled at haproxy layer.