### PR TITLE
Updated trilio-data-mover upgrade for moving from py2 to py3

### DIFF
--- a/juju-charms/charm-trilio-data-mover/unit_tests/test_data_mover.py
+++ b/juju-charms/charm-trilio-data-mover/unit_tests/test_data_mover.py
@@ -130,7 +130,6 @@ class Test(unittest.TestCase):
          self.patch(datamover, 'config')
          self.config.return_value = 's3'
          self.patch(datamover, 'apt_update')
-         self.patch(datamover, 'apt_upgrade')
          self.patch(datamover, 'status_set')
          self.patch(datamover, 'validate_backup')
          self.validate_backup.return_value = True
@@ -158,7 +157,6 @@ class Test(unittest.TestCase):
     def test_s3_object_storage_pass(self):
          self.patch(datamover, 'config')
          self.patch(datamover, 'apt_update')
-         self.patch(datamover, 'apt_upgrade')
          self.patch(datamover, 'status_set')
          self.patch(datamover, 'validate_backup')
          self.validate_backup.return_value = True


### PR DESCRIPTION
1. Removed apt_upgrade from install
2. Updated Upgrade hook by checking existing contego packages and then removing those before installing new