### PR TITLE
No-op the update stanza

### DIFF
--- a/redhat-director-scripts/docker/services/trilio-datamover-api.yaml
+++ b/redhat-director-scripts/docker/services/trilio-datamover-api.yaml
@@ -104,9 +104,4 @@ outputs:
             setype: "{{ item.setype }}"
           with_items:
             - { 'path': /var/log/containers/trilio-datamover-api, 'setype': svirt_sandbox_file_t }
-      upgrade_tasks:
-        - when: step|int == 0
-          tags: common
-        - when: step|int == 1
-        - when: step|int == 2
-        - when: step|int == 3
+      upgrade_tasks: []

--- a/redhat-director-scripts/docker/services/trilio-datamover.yaml
+++ b/redhat-director-scripts/docker/services/trilio-datamover.yaml
@@ -166,9 +166,4 @@ outputs:
           with_items:
             - { 'path': /var/lib/nova/triliovault-mounts, 'setype': svirt_sandbox_file_t }
             - { 'path': /var/log/containers/trilio-datamover, 'setype': svirt_sandbox_file_t }
-      upgrade_tasks:
-        - when: step|int == 0
-          tags: common
-        - when: step|int == 1
-        - when: step|int == 2
-      
+      upgrade_tasks: []


### PR DESCRIPTION
The current update_tasks stanza breaks minor updates on RHOSP 13.
This commit no-ops this and allows the update playbooks to complete.