### PR TITLE
V4.0maintenance TVAULT-3968

### DIFF
--- a/redhat-director-scripts/docker/services/trilio-datamover-api-osp16.yaml
+++ b/redhat-director-scripts/docker/services/trilio-datamover-api-osp16.yaml
@@ -51,7 +51,9 @@ outputs:
       config_settings:
         trilio::dmapi::dmapi_port: {get_param: DmApiPort}
         trilio::dmapi::dmapi_ssl_port: {get_param: DmApiSslPort}
-        tripleo::trilio_datamover_api::haproxy_endpoints:
+      service_config_settings:
+        haproxy:        
+          tripleo::trilio_datamover_api::haproxy_endpoints:
             trilio_datamover_api:
                 public_virtual_ip: "%{hiera('public_virtual_ip')}"
                 internal_ip: "%{hiera('trilio_datamover_api_vip')}"

--- a/redhat-director-scripts/docker/trilio-horizon-plugin/Dockerfile_rhosp16.1
+++ b/redhat-director-scripts/docker/trilio-horizon-plugin/Dockerfile_rhosp16.1
@@ -17,6 +17,9 @@ RUN rm /etc/yum.repos.d/trilio.repo
 ##Move necessary files
 ADD usr/share/openstack-dashboard/openstack_dashboard/local/enabled/* /usr/share/openstack-dashboard/openstack_dashboard/local/enabled/
 ADD usr/share/openstack-dashboard/openstack_dashboard/templatetags/* /usr/share/openstack-dashboard/openstack_dashboard/templatetags/
+RUN /usr/share/openstack-dashboard/manage.py collectstatic --clear --noinput
+RUN /usr/share/openstack-dashboard/manage.py compress --force
+
 
 ## Add license
 RUN mkdir /licenses


### PR DESCRIPTION
-- Added manage.py fix in horizon dockerfile
-- Recreated and Published new containers to dockerhub with tag 4.0.115-rhosp16.1
-- Added fix for TVAULT-3811 in the same PR.