### PR TITLE
TVAULT-3977:[OSA Ussuri ] Trilio Components deployment failed at Task 'Include vars of /tmp/connection_string into the 'tvault_vars' variable'

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -18,7 +18,7 @@
   template: src="sync_static.py" dest="/tmp/sync_static.py"
 
 - name: Change the working directory to horizon and excute shell command
-  shell: "{{virtual_env}} && {PYTHON_VERSION}} {{ MANAGE_FILE }} shell < /tmp/sync_static.py &> /dev/null"
+  shell: "{{virtual_env}} && {{PYTHON_VERSION}} {{ MANAGE_FILE }} shell < /tmp/sync_static.py &> /dev/null"
   args:
        chdir: "{{HORIZON_PATH}}"
   notify:


### PR DESCRIPTION
"{" was  missing .