### PR TITLE
[TVAULT-3989] Datamover container stuck in restarting state due to rootwrap.conf absent in datamover

### DIFF
--- a/kolla-ansible/trilio-datamover/Dockerfile_pike_ubuntu
+++ b/kolla-ansible/trilio-datamover/Dockerfile_pike_ubuntu
@@ -13,7 +13,6 @@ LABEL name="kolla/trilio-datamover" \
 USER root
 
 ##Install datamover packages
-RUN rm -f /etc/nova/rootwrap.conf
 ADD trilio.list /etc/apt/sources.list.d/
 RUN apt-get update -y
 RUN apt-get install -y tvault-contego --allow-unauthenticated

--- a/kolla-ansible/trilio-datamover/Dockerfile_queens_ubuntu
+++ b/kolla-ansible/trilio-datamover/Dockerfile_queens_ubuntu
@@ -13,7 +13,6 @@ LABEL name="kolla/trilio-datamover" \
 USER root
 
 ##Install datamover packages
-RUN rm -f /etc/nova/rootwrap.conf
 ADD trilio.list /etc/apt/sources.list.d/
 RUN apt-get update -y
 RUN apt-get install -y tvault-contego --allow-unauthenticated

--- a/kolla-ansible/trilio-datamover/Dockerfile_rocky_ubuntu
+++ b/kolla-ansible/trilio-datamover/Dockerfile_rocky_ubuntu
@@ -13,7 +13,6 @@ LABEL name="kolla/trilio-datamover" \
 USER root
 
 ##Install datamover packages
-RUN rm -f /etc/nova/rootwrap.conf
 ADD trilio.list /etc/apt/sources.list.d/
 RUN apt-get update -y
 RUN apt-get install -y tvault-contego --allow-unauthenticated

--- a/kolla-ansible/trilio-datamover/Dockerfile_stein_ubuntu
+++ b/kolla-ansible/trilio-datamover/Dockerfile_stein_ubuntu
@@ -13,7 +13,6 @@ LABEL name="kolla/trilio-datamover" \
 USER root
 
 ##Install datamover packages
-RUN rm -f /etc/nova/rootwrap.conf
 ADD trilio.list /etc/apt/sources.list.d/
 RUN apt-get update -y
 RUN apt-get install -y tvault-contego --allow-unauthenticated

--- a/kolla-ansible/trilio-datamover/Dockerfile_train_ubuntu
+++ b/kolla-ansible/trilio-datamover/Dockerfile_train_ubuntu
@@ -13,7 +13,6 @@ LABEL name="kolla/trilio-datamover" \
 USER root
 
 ##Install datamover packages
-RUN rm -f /etc/nova/rootwrap.conf
 ADD trilio.list /etc/apt/sources.list.d/
 RUN apt-get update -y
 RUN apt-get install -y python3-tvault-contego python3-s3-fuse-plugin --allow-unauthenticated

--- a/kolla-ansible/trilio-datamover/Dockerfile_ussuri_ubuntu
+++ b/kolla-ansible/trilio-datamover/Dockerfile_ussuri_ubuntu
@@ -13,7 +13,6 @@ LABEL name="kolla/trilio-datamover" \
 USER root
 
 ##Install datamover packages
-RUN rm -f /etc/nova/rootwrap.conf
 ADD trilio.list /etc/apt/sources.list.d/
 RUN apt-get update -y
 RUN apt-get install -y python3-tvault-contego python3-s3-fuse-plugin --allow-unauthenticated


### PR DESCRIPTION
Removed invalid step from Dockerfiles present for the Ubuntu platform.
