### PR TITLE
Fix For the TVAULT-4118

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
+++ b/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
@@ -164,7 +164,7 @@ triliovault_docker_password: ""
 triliovault_docker_registry: "docker.io"
 
 
-## triliovault backup target possible values: 'nfs'/'amazon_s3'/'ceph_s3'
+## triliovault backup target possible values: 'nfs'/'amazon_s3'/'other_s3_compatible'
 triliovault_backup_target: 'nfs'
 
 ### 'NFS' backup target details
@@ -175,17 +175,17 @@ triliovault_nfs_shares: '192.168.122.101:/opt/tvault'
 triliovault_nfs_options: 'nolock,soft,timeo=180,intr,lookupcache=none'
 
 
-### 'amazon_s3/ceph_s3' backup target details
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 access key
+### 'amazon_s3/other_s3_compatible' backup target details
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 access key
 triliovault_s3_access_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 secret key
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 secret key
 triliovault_s3_secret_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 region
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 region
 ## if your s3 does not have any region, just keep the parameter as it is
 triliovault_s3_region_name: 'us-east-1'
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 bucket name
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 bucket name
 triliovault_s3_bucket_name: ''
-## Valid for 'ceph_s3' backup target only, provide S3 endpoint url
+## Valid for 'other_s3_compatible' backup target only, provide S3 endpoint url
 ## This paramter is not valid for Amazon S3 backup target type, keep it as it is
 triliovault_s3_endpoint_url: ''
 ## Valid for 'ceph_s3' backup target only, If SSL is enabled on S3 endpoint url then change it to 'True', otherwise keep it as 'False'

--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-datamover.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-datamover.conf.j2
@@ -62,7 +62,7 @@ keyring_ext = .{{ ceph_cinder_user }}.keyring
 [contego_sys_admin]
 helper_command = sudo /usr/bin/privsep-helper
 
-{% if triliovault_backup_target == "ceph_s3" or triliovault_backup_target == "other_s3_compatible" %}
+{% if triliovault_backup_target == "other_s3_compatible" or triliovault_backup_target == "amazon_s3" %}
 
 [s3fuse_sys_admin]
 helper_command = sudo /usr/bin/privsep-helper

--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-datamover.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-datamover.conf.j2
@@ -18,7 +18,7 @@ vault_s3_signature_version = {{ triliovault_s3_version }}
 vault_s3_auth_version = {{ triliovault_s3_auth_version }}
 vault_s3_ssl_cert =
 
-{% elif triliovault_backup_target == "ceph_s3" %}
+{% elif triliovault_backup_target == "other_s3_compatible" %}
 
 vault_storage_type = s3
 vault_storage_nfs_export = TrilioVault
@@ -62,7 +62,7 @@ keyring_ext = .{{ ceph_cinder_user }}.keyring
 [contego_sys_admin]
 helper_command = sudo /usr/bin/privsep-helper
 
-{% if triliovault_backup_target == "ceph_s3" or triliovault_backup_target == "amazon_s3" %}
+{% if triliovault_backup_target == "ceph_s3" or triliovault_backup_target == "other_s3_compatible" %}
 
 [s3fuse_sys_admin]
 helper_command = sudo /usr/bin/privsep-helper

--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-datamover.json.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-datamover.json.j2
@@ -1,5 +1,5 @@
 {    
-    {% set triliovault_backup_target_type = 's3' if triliovault_backup_target in ['amazon_s3', 'ceph_s3'] else 'nfs' %}	
+    {% set triliovault_backup_target_type = 's3' if triliovault_backup_target in ['amazon_s3', 'other_s3_compatible'] else 'nfs' %}	
 
     "command": "/opt/tvault/start_datamover_{{ triliovault_backup_target_type }}",
     "config_files": [

--- a/kolla-ansible/ansible/triliovault_globals.yml
+++ b/kolla-ansible/ansible/triliovault_globals.yml
@@ -25,7 +25,7 @@ triliovault_docker_registry: "docker.io"
 
 
 
-## triliovault backup target possible values: 'nfs'/'amazon_s3'/'ceph_s3'
+## triliovault backup target possible values: 'nfs'/'amazon_s3'/'other_s3_compatible'
 triliovault_backup_target: 'nfs'
 
 ### 'NFS' backup target details
@@ -36,17 +36,17 @@ triliovault_nfs_shares: '192.168.122.101:/opt/tvault'
 triliovault_nfs_options: 'nolock,soft,timeo=180,intr,lookupcache=none'
 
 
-### 'amazon_s3/ceph_s3' backup target details
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 access key
+### 'amazon_s3/other_s3_compatible' backup target details
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 access key
 triliovault_s3_access_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 secret key
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 secret key
 triliovault_s3_secret_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 region
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 region
 ## if your s3 does not have any region, just keep the parameter as it is
 triliovault_s3_region_name: 'us-east-1'
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 bucket name
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 bucket name
 triliovault_s3_bucket_name: ''
-## Valid for 'ceph_s3' backup target only, provide S3 endpoint url
+## Valid for 'other_s3_compatible' backup target only, provide S3 endpoint url
 ## This paramter is not valid for Amazon S3 backup target type, keep it as it is
 triliovault_s3_endpoint_url: ''
 
@@ -56,7 +56,7 @@ triliovault_s3_version: 'default'
 ## S3 Auth version
 triliovault_s3_auth_version: 'DEFAULT'
 
-## Valid for 'ceph_s3' backup target only, If SSL is enabled on S3 endpoint url then change it to 'True', otherwise keep it as 'False'
+## Valid for 'other_s3_compatible' backup target only, If SSL is enabled on S3 endpoint url then change it to 'True', otherwise keep it as 'False'
 triliovault_s3_ssl_enabled: False
 ## Valid for 'ceph_s3' backup target only, if SSL is enabled on S3 endpoint URL and SSL certificates are self signed
 # OR issued by a private authority then, user needs to copy the 'ceph s3 ca chain file' to "/etc/kolla/config/triliovault/" 


### PR DESCRIPTION
Adde fix for the TVAULT-4118
Instead of ceph_s3 backup target for wasabi, we can specify in the globals.yml file other_s3_compatible for both that is ceph_s3 & wasabi_s3.