### PR TITLE
TVAULT-4339 Haproxy timeouts to be set with default values for TrilioDMAPI 

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
+++ b/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
@@ -18,6 +18,14 @@ triliovault_services:
         port: "{{ triliovault_datamover_api_port }}"
         listen_port: "{{ triliovault_datamover_api_listen_port }}"
         tls_backend: "{{ triliovault_enable_tls_backend }}"
+        haproxy_http_request_timeout: "{{ haproxy_http_request_timeout }}"
+        haproxy_queue_timeout: "{{ haproxy_queue_timeout }}"
+        haproxy_connect_timeout: "{{ haproxy_connect_timeout }}"
+        haproxy_client_timeout: "{{ haproxy_client_timeout }}"
+        haproxy_server_timeout: "{{ haproxy_server_timeout }}"
+        haproxy_check_timeout: "{{ haproxy_check_timeout }}"
+        haproxy_defaults_balance: "{{ haproxy_defaults_balance }}"
+        haproxy_defaults_max_connections: "{{ haproxy_defaults_max_connections }}"
       triliovault_datamover_api_external:
         enabled: "{{ enable_triliovault }}"
         mode: "http"
@@ -164,7 +172,7 @@ triliovault_docker_password: ""
 triliovault_docker_registry: "docker.io"
 
 
-## triliovault backup target possible values: 'nfs'/'amazon_s3'/'ceph_s3'
+## triliovault backup target possible values: 'nfs'/'amazon_s3'/'other_s3_compatible'
 triliovault_backup_target: 'nfs'
 
 ### 'NFS' backup target details
@@ -175,17 +183,17 @@ triliovault_nfs_shares: '192.168.122.101:/opt/tvault'
 triliovault_nfs_options: 'nolock,soft,timeo=180,intr,lookupcache=none'
 
 
-### 'amazon_s3/ceph_s3' backup target details
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 access key
+### 'amazon_s3/other_s3_compatible' backup target details
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 access key
 triliovault_s3_access_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 secret key
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 secret key
 triliovault_s3_secret_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 region
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 region
 ## if your s3 does not have any region, just keep the parameter as it is
 triliovault_s3_region_name: 'us-east-1'
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 bucket name
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 bucket name
 triliovault_s3_bucket_name: ''
-## Valid for 'ceph_s3' backup target only, provide S3 endpoint url
+## Valid for 'other_s3_compatible' backup target only, provide S3 endpoint url
 ## This paramter is not valid for Amazon S3 backup target type, keep it as it is
 triliovault_s3_endpoint_url: ''
 ## Valid for 'ceph_s3' backup target only, If SSL is enabled on S3 endpoint url then change it to 'True', otherwise keep it as 'False'

--- a/kolla-ansible/ansible/triliovault_globals.yml
+++ b/kolla-ansible/ansible/triliovault_globals.yml
@@ -14,9 +14,6 @@ triliovault_horizon_image_full: "{{ triliovault_docker_registry }}/trilio/{{ kol
 
 ## Triliovault dmapi_workers count
 ## Default value of dmapi_workers is 2
-## This parameter value used to spawn the number of dmapi processes to handle the incoming api requests.
-## If your dmapi node has ‘n' cpu cores, It is recommended, to set this parameter to '4*n’.
-## If dmapi_workers field is not present in config file. The Default value will be equals to number of cores present on the node
 dmapi_workers: '2'
 
 ## TrilioVault's containers tag
@@ -28,7 +25,7 @@ triliovault_docker_registry: "docker.io"
 
 
 
-## triliovault backup target possible values: 'nfs'/'amazon_s3'/'ceph_s3'
+## triliovault backup target possible values: 'nfs'/'amazon_s3'/'other_s3_compatible'
 triliovault_backup_target: 'nfs'
 
 ### 'NFS' backup target details
@@ -39,17 +36,17 @@ triliovault_nfs_shares: '192.168.122.101:/opt/tvault'
 triliovault_nfs_options: 'nolock,soft,timeo=180,intr,lookupcache=none'
 
 
-### 'amazon_s3/ceph_s3' backup target details
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 access key
+### 'amazon_s3/other_s3_compatible' backup target details
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 access key
 triliovault_s3_access_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 secret key
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 secret key
 triliovault_s3_secret_key: ''
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 region
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 region
 ## if your s3 does not have any region, just keep the parameter as it is
 triliovault_s3_region_name: 'us-east-1'
-## Valid for 'amazon_s3'/'ceph_s3' backup target, provide S3 bucket name
+## Valid for 'amazon_s3'/'other_s3_compatible' backup target, provide S3 bucket name
 triliovault_s3_bucket_name: ''
-## Valid for 'ceph_s3' backup target only, provide S3 endpoint url
+## Valid for 'other_s3_compatible' backup target only, provide S3 endpoint url
 ## This paramter is not valid for Amazon S3 backup target type, keep it as it is
 triliovault_s3_endpoint_url: ''
 
@@ -59,7 +56,7 @@ triliovault_s3_version: 'default'
 ## S3 Auth version
 triliovault_s3_auth_version: 'DEFAULT'
 
-## Valid for 'ceph_s3' backup target only, If SSL is enabled on S3 endpoint url then change it to 'True', otherwise keep it as 'False'
+## Valid for 'other_s3_compatible' backup target only, If SSL is enabled on S3 endpoint url then change it to 'True', otherwise keep it as 'False'
 triliovault_s3_ssl_enabled: False
 ## Valid for 'ceph_s3' backup target only, if SSL is enabled on S3 endpoint URL and SSL certificates are self signed
 # OR issued by a private authority then, user needs to copy the 'ceph s3 ca chain file' to "/etc/kolla/config/triliovault/" 
@@ -71,3 +68,14 @@ triliovault_s3_ssl_cert_file_name: 's3-cert.pem'
 ## then, user needs to set this parameter value to: True , otherwise keep it's value as False.
 ## Type: Boolean
 triliovault_copy_ceph_s3_ssl_cert: False
+
+## Set haproxy timout for triliovault dmapi service
+## these changes are reflected into the /etc/kolla/haproxy/haproxy.cfg 
+haproxy_http_request_timeout: '10m'
+haproxy_queue_timeout: '10m'
+haproxy_connect_timeout: '10m'
+haproxy_client_timeout: '10m'
+haproxy_server_timeout: '10m'
+haproxy_check_timeout: '10m'
+haproxy_defaults_balance: 'roundrobin'
+haproxy_defaults_max_connections: '50000'


### PR DESCRIPTION
Tested and verified the values are get reflected correctly into the /etc/kolla/haproxy/haproxy.cfg
Below are the default values of haproxy for triliovault-dampi

```
defaults
    log global
    option redispatch
    retries 5
    timeout http-request 20s
    timeout queue 10m
    timeout connect 20s
    timeout client 5m
    timeout server 5m
    timeout check 20s
    balance roundrobin
    maxconn 50000
```