### PR TITLE
TVAULT-3389: Added script to instal triliovault puppet module in  overcloud qcow2

### DIFF
--- a/redhat-director-scripts/common/install_puppet_module.sh
+++ b/redhat-director-scripts/common/install_puppet_module.sh
@@ -15,14 +15,6 @@ overcloud_full_image_path=$1
 rpm_repo_user=$2
 rpm_repo_password=$3
 
-tmp_working_dir="/tmp/triliovault"
-overcloud_full_image_name=`basename $overcloud_full_image_path`
-
-
-rm -rf $tmp_working_dir
-mkdir -p $tmp_working_dir
-cp $overcloud_full_image_path ${tmp_working_dir}/
-
 cat > trilio.repo <<EOF
 [triliovault-4-1]
 name=triliovault-4-1
@@ -31,24 +23,16 @@ gpgcheck=0
 enabled=1
 EOF
 
-cp trilio.repo virt_commands ${tmp_working_dir}/
-
-
 
 export LIBGUESTFS_BACKEND=direct
 
-virt-customize --selinux-relabel -a ${overcloud_full_image_name} --commands-from-file ./virt_commands
+virt-customize --selinux-relabel -a ${overcloud_full_image_path} --commands-from-file ./virt_commands
 
-virt-customize --selinux-relabel -a ${overcloud_full_image_name} --run-command  'ln -s /usr/share/openstack-puppet/modules/trilio /etc/puppet/modules/trilio && rm -f /etc/yum.repos.d/trilio.repo'
+virt-customize --selinux-relabel -a ${overcloud_full_image_path} --run-command  'ln -s /usr/share/openstack-puppet/modules/trilio /etc/puppet/modules/trilio && rm -f /etc/yum.repos.d/trilio.repo'
 
-virt-sysprep --operation machine-id -a ${overcloud_full_image_name}
+virt-sysprep --operation machine-id -a ${overcloud_full_image_path}
 
-echo -e "Updated overcloud full image path is: ${tmp_working_dir}/${overcloud_full_image_name}"
+echo -e "Updated overcloud full image path is: ${overcloud_full_image_path}"
 echo -e "TrilioVault puppet module is installed in the overcloud image"
-echo -e "You need to copy(overwrite) this image to your overcloud images location. Default location is /home/stack/images"
-echo -e "Then you need to upload updated images to undercloud glance using following command"
-echo -e "openstack overcloud image upload --image-path /home/stack/images/"
-
-## To verify the changes, use following steps
-# mkdir /tmp/mnt
-# guestmount -a /home/stack/test/overcloud-full.qcow2 -m /dev/sda /tmp/mnt
+echo -e "You need to upload updated images to undercloud glance using following command"
+echo -e "openstack overcloud image upload --image-path --update-existing /home/stack/images/"

--- a/redhat-director-scripts/common/install_puppet_module.sh
+++ b/redhat-director-scripts/common/install_puppet_module.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -x
+
+set -e
+
+if [ $# -lt 1 ];then
+   echo "Script takes exacyly 1 argument"
+   echo -e "./install_puppet_module.sh <overcloud_full_image_path>"
+   echo -e "Example"
+   echo -e "./install_puppet_module.sh /home/stack/images/overcloud-full.qcow2"
+   exit 1
+fi
+
+overcloud_full_image_path=$1
+tmp_working_dir="/tmp/triliovault"
+overcloud_full_image_name=`basename $overcloud_full_image_path`
+
+
+rm -rf $tmp_working_dir
+mkdir -p $tmp_working_dir
+cp $overcloud_full_image_path ${tmp_working_dir}/
+cp trilio.repo ${tmp_working_dir}/
+
+cd ${tmp_working_dir}/
+virt-customize --selinux-relabel -a ${overcloud_full_image_name} --upload trilio.repo:/etc/yum.repos.d/
+virt-customize --selinux-relabel -a ${overcloud_full_image_name} --install puppet-triliovault
+virt-customize --selinux-relabel -a ${overcloud_full_image_name} --run-command  'ln -s /usr/share/openstack-puppet/modules/trilio /etc/puppet/modules/trilio && rm -f /etc/yum.repos.d/trilio.repo'
+
+
+echo -e "Updated overcloud full image path is: ${tmp_working_dir}/${overcloud_full_image_name}"
+echo -e "TrilioVault puppet module is installed in the overcloud image"
+echo -e "You need to copy(overwrite) this image to your overcloud images location. Default location is /home/stack/images"
+echo -e "Then you need to upload updated images to undercloud glance using following command"
+echo -e "openstack overcloud image upload --image-path /home/stack/images/"
+
+## To verify the changes, use following steps
+# mkdir /tmp/mnt
+# guestmount -a /home/stack/test/overcloud-full.qcow2 -m /dev/sda /tmp/mnt

--- a/redhat-director-scripts/common/trilio.repo
+++ b/redhat-director-scripts/common/trilio.repo
@@ -1,5 +1,0 @@
-[triliovault-4-1]
-name=triliovault-4-1
-baseurl=http://trilio:XpmkpMFviqSe@repos.trilio.io:8283/triliovault-4.1-dev/yum/
-gpgcheck=0
-enabled=1

--- a/redhat-director-scripts/common/trilio.repo
+++ b/redhat-director-scripts/common/trilio.repo
@@ -1,0 +1,5 @@
+[triliovault-4-1]
+name=triliovault-4-1
+baseurl=http://trilio:XpmkpMFviqSe@repos.trilio.io:8283/triliovault-4.1-dev/yum/
+gpgcheck=0
+enabled=1

--- a/redhat-director-scripts/common/virt_commands
+++ b/redhat-director-scripts/common/virt_commands
@@ -1,0 +1,2 @@
+upload trilio.repo:/etc/yum.repos.d/
+install puppet-triliovault


### PR DESCRIPTION
-- This script is capable of installing triliovault puppet module into overcloud full qcow2 image.
-- This is required to support scenarios like triliovault installation during cloud scale up and fresh cloud installations.