### PR TITLE
TVAULT-4710 Added task to Load the nbd module and create 128 devices

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -16,15 +16,35 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Load nbd and create 128 devices
+- name: Generate modules.dep and map files
+  shell: depmod -a
+  register: depmod_reg
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ depmod_reg }}"
+  when: depmod_reg.rc != 0
+
+- name: Create nbd 128 devices
+  shell: sudo modprobe nbd nbds_max=128
+  register: crt_nbd
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ crt_nbd }}"
+  when: crt_nbd.rc != 0
+
+- name: Load nbd 128 devices
   lineinfile:
     path: /etc/rc.modules
     line: 'depmod -a && sudo modprobe nbd nbds_max=128'
     create: yes
   register: chk_nbd
+  ignore_errors: yes
 
 - debug:
     msg: "{{ chk_nbd }}"
+  when: crt_nbd.rc != 0
 
 - name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
   package:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -10,15 +10,36 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Load nbd and create 128 devices
+- name: Generate modules.dep and map files
+  shell: depmod -a
+  register: depmod_reg
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ depmod_reg }}"
+  when: depmod_reg.rc != 0
+
+- name: Create nbd 128 devices
+  shell: sudo modprobe nbd nbds_max=128
+  register: crt_nbd
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ crt_nbd }}"
+  when: crt_nbd.rc != 0
+
+- name: Load nbd 128 devices
   lineinfile:
     path: /etc/rc.modules
     line: 'depmod -a && sudo modprobe nbd nbds_max=128'
     create: yes
   register: chk_nbd
+  ignore_errors: yes
 
 - debug:
     msg: "{{ chk_nbd }}"
+  when: crt_nbd.rc != 0
+
 
 - name: Download contego virtenv deb package
   shell: |
@@ -41,5 +62,8 @@
           dpkg --configure -a && apt-get -o Dpkg::Options::="--force-confold" install ./python3-tvault-contego_{{ TVAULT_PACKAGE_VERSION }}_all.deb -y
           rm -rf python3-tvault-contego_{{ TVAULT_PACKAGE_VERSION }}_all.deb
   when: PYTHON_VERSION=="python3"
+
+
+
 
 


### PR DESCRIPTION
Linux command which Loads the NBD module and creates 128 devices into _/etc/rc.modules_

1. If already present with nbd cmd then it will ignore
2. If a file is not present create and add cmd `depmod -a && sudo modprobe nbd nbds_max=128 ` 
