### PR TITLE
TVAULT-4710 load the nbd module and create 128 devices & TVAULT-4683 added centos openstack repo to install python3-contegoclient-el8 python3-workloadmgrclient-el8

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -16,15 +16,35 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Load nbd and create 128 devices
+- name: Generate modules.dep and map files
+  shell: depmod -a
+  register: depmod_reg
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ depmod_reg }}"
+  when: depmod_reg.rc != 0
+
+- name: Create nbd 128 devices
+  shell: sudo modprobe nbd nbds_max=128
+  register: crt_nbd
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ crt_nbd }}"
+  when: crt_nbd.rc != 0
+
+- name: Load nbd 128 devices
   lineinfile:
     path: /etc/rc.modules
     line: 'depmod -a && sudo modprobe nbd nbds_max=128'
     create: yes
   register: chk_nbd
+  ignore_errors: yes
 
 - debug:
     msg: "{{ chk_nbd }}"
+  when: crt_nbd.rc != 0
 
 - name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
   package:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -16,8 +16,15 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Load the nbd module and create 128 devices
-  shell: grep -qxF "depmod -a && sudo modprobe nbd nbds_max=128" "/etc/rc.modules" || echo "depmod -a && sudo modprobe nbd nbds_max=128" >> "/etc/rc.modules"
+- name: Load nbd and create 128 devices
+  lineinfile:
+    path: /etc/rc.modules
+    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
+    create: yes
+  register: chk_nbd
+
+- debug:
+    msg: "{{ chk_nbd }}"
 
 - name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
   package:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -16,6 +16,15 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
+- name: Load the nbd module and create 128 devices
+  shell: grep -qxF "depmod -a && sudo modprobe nbd nbds_max=128" "/etc/rc.modules" || echo "depmod -a && sudo modprobe nbd nbds_max=128" >> "/etc/rc.modules"
+
+- name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
+  package:
+    name: centos-release-openstack-{{OPENSTACK_DIST | lower}}
+    state: latest
+  register: inst_pckg
+
 - name: install contego extension packages when using python2
   yum:
      update_cache: yes
@@ -33,3 +42,9 @@
         - python3-tvault-contego
      state: latest
   when: PYTHON_VERSION=="python3"
+
+- name: Remove recently installed openstack-{{OPENSTACK_DIST}} repo
+  package:
+    name: centos-release-openstack-{{OPENSTACK_DIST | lower}}
+    state: absent
+  when: (inst_pckg.changed == 'True')

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -10,6 +10,9 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
+- name: Load the nbd module and create 128 devices 
+  shell: grep -qxF "depmod -a && sudo modprobe nbd nbds_max=128" "/etc/rc.modules" || echo "depmod -a && sudo modprobe nbd nbds_max=128" >> "/etc/rc.modules"
+
 - name: Download contego virtenv deb package
   shell: |
           curl -Og6 http://{{ IP_ADDRESS }}:{{ PORT_NO }}/deb-repo/deb-repo/tvault-contego-extension_{{ TVAULT_PACKAGE_VERSION }}_all.deb

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -10,8 +10,15 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Load the nbd module and create 128 devices 
-  shell: grep -qxF "depmod -a && sudo modprobe nbd nbds_max=128" "/etc/rc.modules" || echo "depmod -a && sudo modprobe nbd nbds_max=128" >> "/etc/rc.modules"
+- name: Load nbd and create 128 devices
+  lineinfile:
+    path: /etc/rc.modules
+    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
+    create: yes
+  register: chk_nbd
+
+- debug:
+    msg: "{{ chk_nbd }}"
 
 - name: Download contego virtenv deb package
   shell: |
@@ -19,7 +26,7 @@
           dpkg --configure -a && apt-get -o Dpkg::Options::="--force-confold" install ./tvault-contego-extension_{{TVAULT_PACKAGE_VERSION}}_all.deb -y
           rm -rf ./tvault-contego-extension_{{ TVAULT_PACKAGE_VERSION }}_all.deb
 
-- debug : msg="curl -Og6 http://{{IP_ADDRESS}}:{{ PORT_NO }}/deb-repo/deb-repo/tvault-contego-extension_{{TVAULT_PACKAGE_VERSION}}_all.deb" verbosity="{{ verbosity_level }}"
+- debug : msg="curl -Og6 http://{{IP_ADDRESS}}:{{ PORT_NO }}/deb-repo/deb-repo/tvault-contego-extension_{{TVAULT_PACKAGE_VERSION}}_all.deb" verbosity={{ verbosity_level }}
 
 - name: install tvault-contego deb package when using python2
   shell: |
@@ -34,8 +41,5 @@
           dpkg --configure -a && apt-get -o Dpkg::Options::="--force-confold" install ./python3-tvault-contego_{{ TVAULT_PACKAGE_VERSION }}_all.deb -y
           rm -rf python3-tvault-contego_{{ TVAULT_PACKAGE_VERSION }}_all.deb
   when: PYTHON_VERSION=="python3"
-
-
-
 
 

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -10,15 +10,36 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Load nbd and create 128 devices
+- name: Generate modules.dep and map files
+  shell: depmod -a
+  register: depmod_reg
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ depmod_reg }}"
+  when: depmod_reg.rc != 0
+
+- name: Create nbd 128 devices
+  shell: sudo modprobe nbd nbds_max=128
+  register: crt_nbd
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ crt_nbd }}"
+  when: crt_nbd.rc != 0
+
+- name: Load nbd 128 devices
   lineinfile:
     path: /etc/rc.modules
     line: 'depmod -a && sudo modprobe nbd nbds_max=128'
     create: yes
   register: chk_nbd
+  ignore_errors: yes
 
 - debug:
     msg: "{{ chk_nbd }}"
+  when: crt_nbd.rc != 0
+
 
 - name: Download contego virtenv deb package
   shell: |
@@ -41,5 +62,8 @@
           dpkg --configure -a && apt-get -o Dpkg::Options::="--force-confold" install ./python3-tvault-contego_{{ TVAULT_PACKAGE_VERSION }}_all.deb -y
           rm -rf python3-tvault-contego_{{ TVAULT_PACKAGE_VERSION }}_all.deb
   when: PYTHON_VERSION=="python3"
+
+
+
 
 


### PR DESCRIPTION
TVAULT-4710 Fix for load the nbd module and create 128 devices
TVAULT-4783 Fix added centos/rhel openstack repo to install python3-contegoclient-el8 python3-workloadmgrclient-el8

**Changes for TVAULT-4783 already merged into dev-stable/4.2 branch need to merge in master branch.**