### PR TITLE
TVAULT- 4710 LOAD NBD MODULE AND TVAULT-4735 LOAD RBD MODULE

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -34,17 +34,29 @@
     msg: "{{ crt_nbd }}"
   when: crt_nbd.rc != 0
 
-- name: Load nbd 128 devices
+- name: Create nbd config file
   lineinfile:
-    path: /etc/rc.modules
-    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
+    path: /etc/modprobe.d/nbd.conf
+    line: 'options nbd nbds_max=128'
     create: yes
   register: chk_nbd
   ignore_errors: yes
 
 - debug:
     msg: "{{ chk_nbd }}"
-  when: crt_nbd.rc != 0
+  when: crt_nbd.changed == False
+
+- name: Load nbd module into Linux Kernel
+  lineinfile:
+    path: /etc/modules-load.d/openstack-ansible.conf
+    line: 'nbd'
+    create: no
+  register: loa_nbd
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ loa_nbd }}"
+  when: loa_nbd.changed == False
 
 - name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
   package:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Stop tvault-objetc-store service if running
   service: name=tvault-object-store state=stopped
   ignore_errors: yes
@@ -15,48 +14,53 @@
 
 - name: Reload Daemon
   shell: systemctl daemon-reload
-
-- name: Generate modules.dep and map files
-  shell: depmod -a
-  register: depmod_reg
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ depmod_reg }}"
-  when: depmod_reg.rc != 0
-
-- name: Create nbd 128 devices
+- name: Run cmd to create nbd 128 devices
   shell: sudo modprobe nbd nbds_max=128
-  register: crt_nbd
+  register: cmd_nbd
   ignore_errors: yes
 
 - debug:
-    msg: "{{ crt_nbd }}"
-  when: crt_nbd.rc != 0
+    msg: "{{ cmd_nbd }}"
+  when: cmd_nbd.changed == False
+  ignore_errors: yes
 
 - name: Create nbd config file
   lineinfile:
     path: /etc/modprobe.d/nbd.conf
     line: 'options nbd nbds_max=128'
     create: yes
-  register: chk_nbd
   ignore_errors: yes
-
-- debug:
-    msg: "{{ chk_nbd }}"
-  when: crt_nbd.changed == False
-
+  
 - name: Load nbd module into Linux Kernel
   lineinfile:
     path: /etc/modules-load.d/openstack-ansible.conf
     line: 'nbd'
     create: no
-  register: loa_nbd
   ignore_errors: yes
 
+- name: Run cmd to create rbd
+  shell: sudo modprobe rbd
+  register: cmd_rbd
+  ignore_errors: yes
+ 
 - debug:
-    msg: "{{ loa_nbd }}"
-  when: loa_nbd.changed == False
+    msg: "{{ cmd_rbd }}"
+  when: cmd_rbd.changed == False
+  ignore_errors: yes
+
+- name: Create rbd config file
+  lineinfile:
+    path: /etc/modprobe.d/rbd.conf
+    line: 'options rbd'
+    create: yes
+  ignore_errors: yes
+
+- name: Load rbd module into Linux Kernel
+  lineinfile:
+    path: /etc/modules-load.d/openstack-ansible.conf
+    line: 'rbd'
+    create: no
+  ignore_errors: yes
 
 - name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
   package:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -10,47 +10,53 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Generate modules.dep and map files
-  shell: depmod -a
-  register: depmod_reg
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ depmod_reg }}"
-  when: depmod_reg.rc != 0
-
-- name: Create nbd 128 devices
+- name: Run cmd to create nbd 128 devices
   shell: sudo modprobe nbd nbds_max=128
-  register: crt_nbd
+  register: cmd_nbd
   ignore_errors: yes
 
 - debug:
-    msg: "{{ crt_nbd }}"
-  when: crt_nbd.rc != 0
+    msg: "{{ cmd_nbd }}"
+  when: cmd_nbd.changed == False
+  ignore_errors: yes
 
 - name: Create nbd config file
   lineinfile:
     path: /etc/modprobe.d/nbd.conf
     line: 'options nbd nbds_max=128'
     create: yes
-  register: chk_nbd
   ignore_errors: yes
-
-- debug:
-    msg: "{{ chk_nbd }}"
-  when: crt_nbd.changed == False
-
+  
 - name: Load nbd module into Linux Kernel
   lineinfile:
     path: /etc/modules-load.d/modules.conf
     line: 'nbd'
     create: no
-  register: loa_nbd
   ignore_errors: yes
 
+- name: Run cmd to create rbd
+  shell: sudo modprobe rbd
+  register: cmd_rbd
+  ignore_errors: yes
+ 
 - debug:
-    msg: "{{ loa_nbd }}"
-  when: loa_nbd.changed == False
+    msg: "{{ cmd_rbd }}"
+  when: cmd_rbd.changed == False
+  ignore_errors: yes
+
+- name: Create rbd config file
+  lineinfile:
+    path: /etc/modprobe.d/rbd.conf
+    line: 'options rbd'
+    create: yes
+  ignore_errors: yes
+
+- name: Load rbd module into Linux Kernel
+  lineinfile:
+    path: /etc/modules-load.d/modules.conf
+    line: 'rbd'
+    create: no
+  ignore_errors: yes
 
 - name: Download contego virtenv deb package
   shell: |

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -28,18 +28,29 @@
     msg: "{{ crt_nbd }}"
   when: crt_nbd.rc != 0
 
-- name: Load nbd 128 devices
+- name: Create nbd config file
   lineinfile:
-    path: /etc/rc.modules
-    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
+    path: /etc/modprobe.d/nbd.conf
+    line: 'options nbd nbds_max=128'
     create: yes
   register: chk_nbd
   ignore_errors: yes
 
 - debug:
     msg: "{{ chk_nbd }}"
-  when: crt_nbd.rc != 0
+  when: crt_nbd.changed == False
 
+- name: Load nbd module into Linux Kernel
+  lineinfile:
+    path: /etc/modules-load.d/modules.conf
+    line: 'nbd'
+    create: no
+  register: loa_nbd
+  ignore_errors: yes
+
+- debug:
+    msg: "{{ loa_nbd }}"
+  when: loa_nbd.changed == False
 
 - name: Download contego virtenv deb package
   shell: |


### PR DESCRIPTION
Added changes to load the nbd and rbd modules before and after compute node reboot

It will run a cmd, create conf files and add modules entry into respective files
Ubuntu: modules.conf
CentOS: openstack-ansible.conf