### PR TITLE
TVAULT-4710 standard code to load nbd driver

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -16,35 +16,24 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Generate modules.dep and map files
-  shell: depmod -a
-  register: depmod_reg
-  ignore_errors: yes
+- name: Triliovault - set nbd module options in modprobe conf
+  become: true
+  template:
+    src: modprobe-nbd.conf.j2
+    dest: "/etc/modprobe.d/nbd.conf"
 
-- debug:
-    msg: "{{ depmod_reg }}"
-  when: depmod_reg.rc != 0
+- name: Triliovault - set module-load conf for nbd module
+  become: true
+  template:
+    src: module-load-nbd.conf.j2
+    dest: "/etc/modules-load.d/nbd.conf"
 
-- name: Create nbd 128 devices
-  shell: sudo modprobe nbd nbds_max=128
-  register: crt_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ crt_nbd }}"
-  when: crt_nbd.rc != 0
-
-- name: Load nbd 128 devices
-  lineinfile:
-    path: /etc/rc.modules
-    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
-    create: yes
-  register: chk_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ chk_nbd }}"
-  when: crt_nbd.rc != 0
+- name: Triliovault - load nbd module
+  become: true
+  modprobe:
+    name: "nbd"
+    params: "nbds_max=128"
+    state: "present"
 
 - name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
   package:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -10,36 +10,24 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Generate modules.dep and map files
-  shell: depmod -a
-  register: depmod_reg
-  ignore_errors: yes
+- name: Triliovault - set nbd module options in modprobe conf
+  become: true
+  template:
+    src: modprobe-nbd.conf.j2
+    dest: "/etc/modprobe.d/nbd.conf"
 
-- debug:
-    msg: "{{ depmod_reg }}"
-  when: depmod_reg.rc != 0
+- name: Triliovault - set module-load conf for nbd module
+  become: true
+  template:
+    src: module-load-nbd.conf.j2
+    dest: "/etc/modules-load.d/nbd.conf"
 
-- name: Create nbd 128 devices
-  shell: sudo modprobe nbd nbds_max=128
-  register: crt_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ crt_nbd }}"
-  when: crt_nbd.rc != 0
-
-- name: Load nbd 128 devices
-  lineinfile:
-    path: /etc/rc.modules
-    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
-    create: yes
-  register: chk_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ chk_nbd }}"
-  when: crt_nbd.rc != 0
-
+- name: Triliovault - load nbd module
+  become: true
+  modprobe:
+    name: "nbd"
+    params: "nbds_max=128"
+    state: "present"
 
 - name: Download contego virtenv deb package
   shell: |

--- a/ansible/roles/ansible-tvault-contego-extension/templates/modprobe-nbd.conf.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/modprobe-nbd.conf.j2
@@ -1,0 +1,1 @@
+options nbd nbds_max=128

--- a/ansible/roles/ansible-tvault-contego-extension/templates/module-load-nbd.conf.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/module-load-nbd.conf.j2
@@ -1,0 +1,2 @@
+#Ansible managed
+nbd


### PR DESCRIPTION
Creates 2 templates files called modprobe-nbd.conf.j2 and module-load-nbd.conf.j2 which are responsible for creating the conf files to load nbd after reboot of compute node(s)
and load the nbd module using ansible module modprobe