### PR TITLE
TVAULT-4735 Load rbd module on compute node

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -16,35 +16,17 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Generate modules.dep and map files
-  shell: depmod -a
-  register: depmod_reg
-  ignore_errors: yes
+- name: Triliovault - set module-load conf for rbd module
+  become: true
+  template:
+    src: module-load-rbd.conf.j2
+    dest: "/etc/modules-load.d/rbd.conf"
 
-- debug:
-    msg: "{{ depmod_reg }}"
-  when: depmod_reg.rc != 0
-
-- name: Create nbd 128 devices
-  shell: sudo modprobe nbd nbds_max=128
-  register: crt_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ crt_nbd }}"
-  when: crt_nbd.rc != 0
-
-- name: Load nbd 128 devices
-  lineinfile:
-    path: /etc/rc.modules
-    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
-    create: yes
-  register: chk_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ chk_nbd }}"
-  when: crt_nbd.rc != 0
+- name: Triliovault - load rbd module
+  become: true
+  modprobe:
+    name: "rbd"
+    state: "present"
 
 - name: Install openstack-{{OPENSTACK_DIST}} repo if is not installed
   package:

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -10,36 +10,17 @@
 - name: Reload Daemon
   shell: systemctl daemon-reload
 
-- name: Generate modules.dep and map files
-  shell: depmod -a
-  register: depmod_reg
-  ignore_errors: yes
+- name: Triliovault - set module-load conf for rbd module
+  become: true
+  template:
+    src: module-load-rbd.conf.j2
+    dest: "/etc/modules-load.d/rbd.conf"
 
-- debug:
-    msg: "{{ depmod_reg }}"
-  when: depmod_reg.rc != 0
-
-- name: Create nbd 128 devices
-  shell: sudo modprobe nbd nbds_max=128
-  register: crt_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ crt_nbd }}"
-  when: crt_nbd.rc != 0
-
-- name: Load nbd 128 devices
-  lineinfile:
-    path: /etc/rc.modules
-    line: 'depmod -a && sudo modprobe nbd nbds_max=128'
-    create: yes
-  register: chk_nbd
-  ignore_errors: yes
-
-- debug:
-    msg: "{{ chk_nbd }}"
-  when: crt_nbd.rc != 0
-
+- name: Triliovault - load rbd module
+  become: true
+  modprobe:
+    name: "rbd"
+    state: "present"
 
 - name: Download contego virtenv deb package
   shell: |

--- a/ansible/roles/ansible-tvault-contego-extension/templates/module-load-rbd.conf.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/module-load-rbd.conf.j2
@@ -1,0 +1,2 @@
+#Ansible managed
+rbd


### PR DESCRIPTION
To load rbd module on compute node provided templates file and task to load on current session using ansible module called **modprobe**