### PR TITLE
TVAULT-4643 minor fixes

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -36,7 +36,7 @@
   file: path=/tmp/sync_static.py state=absent
 
 - name: Get os_local_settings_path
-  shell: find "{{virtual_env}}" -type d -path /sys -prune -o -name "*local_settings.d" 2>/dev/null | grep -E 'openstack_dashboard|horizon'
+  shell: find / -type d -path /sys -prune -o -name "*local_settings.d" 2>/dev/null | grep -E 'openstack_dashboard|horizon'
   register: os_local_settings_path
 
 - name: HORIZON_CONFIG

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -30,7 +30,7 @@
   find:
     patterns: 'site-packages'
     paths:
-      - "{{horizon_virtual_env}}"
+      - /openstack/
     file_type: directory
     recurse: yes
   register: file_found
@@ -40,7 +40,4 @@
 - debug:
     msg: "{{HORIZON_PATH}}"
     verbosity: "{{verbosity_level}}"
-
-
-
 


### PR DESCRIPTION
A virtual path is not required while getting os_local_settings_path
Find openstack-dashboard path in horizon container task reverted