### PR TITLE
Tvault 4749 

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -36,8 +36,14 @@
   file: path=/tmp/sync_static.py state=absent
 
 - name: Get os_local_settings_path
-  shell: find "{{virtual_env}}" -type d -path /sys -prune -o -name "*local_settings.d" 2>/dev/null | grep -E 'openstack_dashboard|horizon'
+  shell: "find {{ horizon_virtual_env }} -type d -path /sys -prune -o -name '*local_settings.d' 2>/dev/null | grep -E 'openstack_dashboard|horizon'"
   register: os_local_settings_path
+
+- debug:
+    msg: "{{ os_local_settings_path }}"
+  tags:
+   - tvault-horizon
+
 
 - name: HORIZON_CONFIG
   shell: echo "HORIZON_CONFIG['customization_module'] = 'dashboards.overrides'" > `echo {{os_local_settings_path.stdout}} | cut -d ' ' -f1 |{ read trilio_setting_path ; echo $trilio_setting_path/_001_trilio_dashboard.py ; }`

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -39,12 +39,6 @@
   shell: "find {{ horizon_virtual_env }} -type d -path /sys -prune -o -name '*local_settings.d' 2>/dev/null | grep -E 'openstack_dashboard|horizon'"
   register: os_local_settings_path
 
-- debug:
-    msg: "{{ os_local_settings_path }}"
-  tags:
-   - tvault-horizon
-
-
 - name: HORIZON_CONFIG
   shell: echo "HORIZON_CONFIG['customization_module'] = 'dashboards.overrides'" > `echo {{os_local_settings_path.stdout}} | cut -d ' ' -f1 |{ read trilio_setting_path ; echo $trilio_setting_path/_001_trilio_dashboard.py ; }`
   when:

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -27,20 +27,15 @@
     verbosity: "{{verbosity_level}}"
 
 - name: Find openstack-dashboard path in horizon container
-  find:
-    patterns: 'site-packages'
-    paths:
-      - "{{horizon_virtual_env}}"
-    file_type: directory
-    recurse: yes
+  shell: "find {{ horizon_virtual_env }} -name 'site-packages'"
   register: file_found
 
-- set_fact: HORIZON_PATH="{{file_found.files[0]['path']}}"
+- debug:
+    msg: "{{ file_found }}"
+
+- set_fact: HORIZON_PATH="{{file_found.stdout_lines[0]}}"
 
 - debug:
     msg: "{{HORIZON_PATH}}"
     verbosity: "{{verbosity_level}}"
-
-
-
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -30,9 +30,6 @@
   shell: "find {{ horizon_virtual_env }} -name 'site-packages'"
   register: file_found
 
-- debug:
-    msg: "{{ file_found }}"
-
 - set_fact: HORIZON_PATH="{{file_found.stdout_lines[0]}}"
 
 - debug:

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -27,10 +27,13 @@
     verbosity: "{{verbosity_level}}"
 
 - name: Find openstack-dashboard path in horizon container
-  shell: "find {{ horizon_virtual_env }} -name 'site-packages'"
-  register: file_found
+  shell: |
+         . {{ horizon_virtual_env }}/bin/activate &&
+         {{ PYTHON_VERSION }} -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'
+  register: HORIZONPATH
 
-- set_fact: HORIZON_PATH="{{file_found.stdout_lines[0]}}"
+- set_fact:
+    HORIZON_PATH: "{{ HORIZONPATH.stdout }}"
 
 - debug:
     msg: "{{HORIZON_PATH}}"


### PR DESCRIPTION
Updated task Get os_local_settings_path with specified horizon_virtual_env 
Added shell command to  _Find openstack-dashboard path in horizon container_ in pre_tasks.yml

Trilio components of build 4.2.29 installation and uninstallation are tested on OSA Victoria CentOS8 working fine.