### PR TITLE
TVAULT-4758 find local sites-packages library path and that can be added into trilio.pth file required to load trilio static files

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/post_install.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/post_install.yml
@@ -10,7 +10,8 @@
   when: ENV_PATH != "/usr"
 
 - name: Found local packages library
-  shell: "{{virtual_env}} && echo $(/usr/bin/{{PYTHON_VERSION}} -c 'import site, os; from os import path; p = [path_dir for path_dir in site.getsitepackages() if path.exists(os.path.join(path_dir, 'dashboards'))]; print(p[0]+'/')')" 
+  shell: |
+         {{ PYTHON_VERSION }} -c "import site, os; from os import path; p = [path_dir for path_dir in site.getsitepackages() if path.exists(os.path.join(path_dir, 'dashboards'))]; print(p[0]+'/')"
   register: PACKAGELIB
   when: ENV_PATH != "/usr"
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/post_install.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/post_install.yml
@@ -11,7 +11,7 @@
 
 - name: Found local packages library
   shell: |
-         {{ PYTHON_VERSION }} -c "import site, os; from os import path; p = [path_dir for path_dir in site.getsitepackages() if path.exists(os.path.join(path_dir, 'dashboards'))]; print(p[0]+'/')"
+         /usr/bin/{{ PYTHON_VERSION }} -c "import site, os; from os import path; p = [path_dir for path_dir in site.getsitepackages() if path.exists(os.path.join(path_dir, 'dashboards'))]; print(p[0]+'/')"
   register: PACKAGELIB
   when: ENV_PATH != "/usr"
 


### PR DESCRIPTION
The issue is that **trilio.pth** is empty if we run the search local **sites-packages** library dir under the **Horizon venv** 
Hence **static files** load got failed and the **trilio-backup-admin** tab was not working.

The fixes are tested on OSA Victoria CentOS8 setup deployment working fine.
TVM and OpenStack configuration is done able to load all the files under [**trilio-backup-admin**] tab

<img width="806" alt="Deployment success" src="https://user-images.githubusercontent.com/67624018/141481549-53420a48-4d48-4f2a-93bc-9333a491f1c6.png">

