### PR TITLE
TVAULT-4669  Enable OPENSTACK_ENCRYPTION_SUPPORT & TRILIO_ENCRYPTION_SUPPORT when Barbican is deployed

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -44,7 +44,7 @@
   when:
     - os_local_settings_path != ""
 
-- set_fact: OPENSTACK_ENCRYPTION={{'True' | default('False')}}
+- set_fact: OPENSTACK_ENCRYPTION=True
   when: > 
     ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0)) and
     (os_local_settings_path != "")
@@ -57,12 +57,10 @@
   when:
     - "{{ OPENSTACK_ENCRYPTION }}==True"
 
-- set_fact: TRILIO_ENCRYPTION={{'True' | default('False')}}
+- set_fact: TRILIO_ENCRYPTION=True
   when: >
-    (ansible_distribution_major_version != "7" and ansible_distribution == "CentOS") or
-    (ansible_distribution_major_version != "7" and ansible_distribution == "RedHat") or
-    (ansible_distribution == "Debian" or ansible_distribution == "Ubuntu") and
-    (os_local_settings_path != "")
+    (ansible_distribution == "CentOS" and ansible_distribution_major_version|int != 7) or
+    (ansible_distribution == "RedHat" and ansible_distribution_major_version|int != 7)  
 
 - name: Enable TRILIO_ENCRYPTION_SUPPORT
   lineinfile:

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -57,8 +57,8 @@
 
 - set_fact: 
     TRILIO_ENCRYPTION: >
-      {{ 'True' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version|int <= 7) or
-      (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int <= 7) else 'False' }}
+      {{ 'True' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version | int <= 7) or
+      (ansible_distribution == 'RedHat' and ansible_distribution_major_version | int <= 7) else 'False' }}
 
 - name: Set TRILIO_ENCRYPTION_SUPPORT
   lineinfile:

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -44,23 +44,33 @@
   when:
     - os_local_settings_path != ""
 
+- set_fact: OPENSTACK_ENCRYPTION={{'True' | default('False')}}
+  when: > 
+    ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0)) and
+    (os_local_settings_path != "")
+
 - name: Enable OPENSTACK_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
     regexp: 'OPENSTACK_ENCRYPTION_SUPPORT'
-    line: OPENSTACK_ENCRYPTION_SUPPORT = True
+    line: OPENSTACK_ENCRYPTION_SUPPORT = {{ OPENSTACK_ENCRYPTION }}
   when:
-   - ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0))
-   - os_local_settings_path != ""
+    - "{{ OPENSTACK_ENCRYPTION }}==True"
+
+- set_fact: TRILIO_ENCRYPTION={{'True' | default('False')}}
+  when: >
+    (ansible_distribution_major_version != "7" and ansible_distribution == "CentOS") or
+    (ansible_distribution_major_version != "7" and ansible_distribution == "RedHat") or
+    (ansible_distribution == "Debian" or ansible_distribution == "Ubuntu") and
+    (os_local_settings_path != "")
 
 - name: Enable TRILIO_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
     regexp: 'TRILIO_ENCRYPTION_SUPPORT'
-    line: TRILIO_ENCRYPTION_SUPPORT = True
+    line: TRILIO_ENCRYPTION_SUPPORT = {{ TRILIO_ENCRYPTION }}
   when:
-   - os_local_settings_path != ""
-   - (ansible_distribution_major_version != "7")
+    - "{{ TRILIO_ENCRYPTION }}==True"
 
 - name: Display local_settings.d path
   debug:

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -44,31 +44,27 @@
   when:
     - os_local_settings_path != ""
 
-- set_fact: OPENSTACK_ENCRYPTION=True
-  when: > 
-    ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0)) and
-    (os_local_settings_path != "")
+- set_fact: 
+    OPENSTACK_ENCRYPTION: >
+      {{ 'True' if ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0)) and
+      (os_local_settings_path != "") else 'False' }}
 
-- name: Enable OPENSTACK_ENCRYPTION_SUPPORT
+- name: Set OPENSTACK_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
     regexp: 'OPENSTACK_ENCRYPTION_SUPPORT'
     line: OPENSTACK_ENCRYPTION_SUPPORT = {{ OPENSTACK_ENCRYPTION }}
-  when:
-    - "{{ OPENSTACK_ENCRYPTION }}==True"
 
-- set_fact: TRILIO_ENCRYPTION=True
-  when: >
-    (ansible_distribution == "CentOS" and ansible_distribution_major_version|int != 7) or
-    (ansible_distribution == "RedHat" and ansible_distribution_major_version|int != 7)  
+- set_fact: 
+    TRILIO_ENCRYPTION: >
+      {{ 'True' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version|int != 7) or
+      (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int != 7) else 'False' }}
 
-- name: Enable TRILIO_ENCRYPTION_SUPPORT
+- name: Set TRILIO_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
     regexp: 'TRILIO_ENCRYPTION_SUPPORT'
     line: TRILIO_ENCRYPTION_SUPPORT = {{ TRILIO_ENCRYPTION }}
-  when:
-    - "{{ TRILIO_ENCRYPTION }}==True"
 
 - name: Display local_settings.d path
   debug:

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -43,7 +43,25 @@
   shell: echo "HORIZON_CONFIG['customization_module'] = 'dashboards.overrides'" > `echo {{os_local_settings_path.stdout}} | cut -d ' ' -f1 |{ read trilio_setting_path ; echo $trilio_setting_path/_001_trilio_dashboard.py ; }`
   when:
     - os_local_settings_path != ""
-    
+
+- name: Enable OPENSTACK_ENCRYPTION_SUPPORT
+  lineinfile:
+    path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
+    regexp: 'OPENSTACK_ENCRYPTION_SUPPORT = False'
+    line: OPENSTACK_ENCRYPTION_SUPPORT = True
+  when:
+   - ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0))
+   - os_local_settings_path != ""
+
+- name: Enable TRILIO_ENCRYPTION_SUPPORT
+  lineinfile:
+    path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
+    regexp: 'TRILIO_ENCRYPTION_SUPPORT = False'
+    line: TRILIO_ENCRYPTION_SUPPORT = True
+  when:
+   - os_local_settings_path != ""
+   - (ansible_distribution_major_version != "7" and ansible_distribution == "CentOS")
+
 - name: Display local_settings.d path
   debug:
     msg: "local_settings.d path: {{os_local_settings_path.stdout}}"

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -76,3 +76,4 @@
 - debug:
     msg: "\033[33m WARNING: Unable to locate local_settings.d on system. Trilio quota feature on dashboard may not work. \033[0m"
     verbosity: "{{ verbosity_level }}"
+  when: os_local_settings_path == ""

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -47,7 +47,7 @@
 - name: Enable OPENSTACK_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
-    regexp: 'OPENSTACK_ENCRYPTION_SUPPORT = False'
+    regexp: 'OPENSTACK_ENCRYPTION_SUPPORT'
     line: OPENSTACK_ENCRYPTION_SUPPORT = True
   when:
    - ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0))
@@ -56,11 +56,12 @@
 - name: Enable TRILIO_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
-    regexp: 'TRILIO_ENCRYPTION_SUPPORT = False'
+    regexp: 'TRILIO_ENCRYPTION_SUPPORT'
     line: TRILIO_ENCRYPTION_SUPPORT = True
   when:
    - os_local_settings_path != ""
-   - (ansible_distribution_major_version != "7" and ansible_distribution == "CentOS")
+   - (ansible_facts['distribution'] == "Debian" or ansible_facts['distribution'] == "CentOS")
+   - (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] != "7")
 
 - name: Display local_settings.d path
   debug:

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -57,8 +57,8 @@
 
 - set_fact: 
     TRILIO_ENCRYPTION: >
-      {{ 'True' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version | int <= 7) or
-      (ansible_distribution == 'RedHat' and ansible_distribution_major_version | int <= 7) else 'False' }}
+      {{ 'False' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version | int <= 7) or
+      (ansible_distribution == 'RedHat' and ansible_distribution_major_version | int <= 7) else 'True' }}
 
 - name: Set TRILIO_ENCRYPTION_SUPPORT
   lineinfile:

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -49,21 +49,22 @@
       {{ 'True' if ((groups['key-manager_hosts'] is defined) and (groups['key-manager_hosts'] | length > 0)) and
       (os_local_settings_path != "") else 'False' }}
 
-- name: Set OPENSTACK_ENCRYPTION_SUPPORT
+- name: SET OPENSTACK_ENCRYPTION_SUPPORT
   lineinfile:
-    path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
-    regexp: 'OPENSTACK_ENCRYPTION_SUPPORT'
+    path: "{{os_local_settings_path.stdout}}/_002_trilio_dashboard.py"
+    regexp: '^OPENSTACK_ENCRYPTION_SUPPORT'
     line: OPENSTACK_ENCRYPTION_SUPPORT = {{ OPENSTACK_ENCRYPTION }}
+    create: yes
 
 - set_fact: 
     TRILIO_ENCRYPTION: >
       {{ 'False' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version | int <= 7) or
       (ansible_distribution == 'RedHat' and ansible_distribution_major_version | int <= 7) else 'True' }}
 
-- name: Set TRILIO_ENCRYPTION_SUPPORT
+- name: SET TRILIO_ENCRYPTION_SUPPORT
   lineinfile:
-    path: "{{os_local_settings_path.stdout}}/_001_trilio_dashboard.py"
-    regexp: 'TRILIO_ENCRYPTION_SUPPORT'
+    path: "{{os_local_settings_path.stdout}}/_002_trilio_dashboard.py"
+    regexp: '^TRILIO_ENCRYPTION_SUPPORT'
     line: TRILIO_ENCRYPTION_SUPPORT = {{ TRILIO_ENCRYPTION }}
 
 - name: Display local_settings.d path
@@ -76,4 +77,3 @@
 - debug:
     msg: "\033[33m WARNING: Unable to locate local_settings.d on system. Trilio quota feature on dashboard may not work. \033[0m"
     verbosity: "{{ verbosity_level }}"
-  when: os_local_settings_path == ""

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -60,8 +60,7 @@
     line: TRILIO_ENCRYPTION_SUPPORT = True
   when:
    - os_local_settings_path != ""
-   - (ansible_facts['distribution'] == "Debian" or ansible_facts['distribution'] == "CentOS")
-   - (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] != "7")
+   - (ansible_distribution_major_version != "7")
 
 - name: Display local_settings.d path
   debug:
@@ -73,5 +72,3 @@
 - debug:
     msg: "\033[33m WARNING: Unable to locate local_settings.d on system. Trilio quota feature on dashboard may not work. \033[0m"
     verbosity: "{{ verbosity_level }}"
-  when: os_local_settings_path == ""
-

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -57,8 +57,8 @@
 
 - set_fact: 
     TRILIO_ENCRYPTION: >
-      {{ 'True' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version|int != 7) or
-      (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int != 7) else 'False' }}
+      {{ 'True' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version|int <= 7) or
+      (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int <= 7) else 'False' }}
 
 - name: Set TRILIO_ENCRYPTION_SUPPORT
   lineinfile:


### PR DESCRIPTION
Enable OPENSTACK_ENCRYPTION_SUPPORT is enabled when key-manager(Barbican) Service is deployed  by-default it's disabled and TRILIO_ENCRYPTION_SUPPORT enable  except CentOS7