### PR TITLE
Tvault 4834 encryption checkbox is missing from workload create tab in UI in 4.2.43

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -52,8 +52,8 @@
 - name: SET OPENSTACK_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_002_trilio_dashboard.py"
-    regexp: '^OPENSTACK_ENCRYPTION_SUPPORT'
-    line: OPENSTACK_ENCRYPTION_SUPPORT = {{ OPENSTACK_ENCRYPTION }}
+    regexp: "^HORIZON_CONFIG\\['OPENSTACK_ENCRYPTION_SUPPORT'\\] "
+    line: HORIZON_CONFIG['OPENSTACK_ENCRYPTION_SUPPORT'] = {{ OPENSTACK_ENCRYPTION }}
     create: yes
 
 - set_fact: 
@@ -64,8 +64,8 @@
 - name: SET TRILIO_ENCRYPTION_SUPPORT
   lineinfile:
     path: "{{os_local_settings_path.stdout}}/_002_trilio_dashboard.py"
-    regexp: '^TRILIO_ENCRYPTION_SUPPORT'
-    line: TRILIO_ENCRYPTION_SUPPORT = {{ TRILIO_ENCRYPTION }}
+    regexp: "^HORIZON_CONFIG\\['TRILIO_ENCRYPTION_SUPPORT'\\] "
+    line: HORIZON_CONFIG['TRILIO_ENCRYPTION_SUPPORT'] = {{ TRILIO_ENCRYPTION }}
 
 - name: Display local_settings.d path
   debug:

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -51,10 +51,9 @@
 
 - name: SET OPENSTACK_ENCRYPTION_SUPPORT
   lineinfile:
-    path: "{{os_local_settings_path.stdout}}/_002_trilio_dashboard.py"
-    regexp: "^HORIZON_CONFIG\\['OPENSTACK_ENCRYPTION_SUPPORT'\\] "
-    line: HORIZON_CONFIG['OPENSTACK_ENCRYPTION_SUPPORT'] = {{ OPENSTACK_ENCRYPTION }}
-    create: yes
+    path: "/etc/horizon/local_settings.py"
+    regexp: "^OPENSTACK_ENCRYPTION_SUPPORT ="
+    line: OPENSTACK_ENCRYPTION_SUPPORT = {{ OPENSTACK_ENCRYPTION }}
 
 - set_fact: 
     TRILIO_ENCRYPTION: >
@@ -63,9 +62,9 @@
 
 - name: SET TRILIO_ENCRYPTION_SUPPORT
   lineinfile:
-    path: "{{os_local_settings_path.stdout}}/_002_trilio_dashboard.py"
-    regexp: "^HORIZON_CONFIG\\['TRILIO_ENCRYPTION_SUPPORT'\\] "
-    line: HORIZON_CONFIG['TRILIO_ENCRYPTION_SUPPORT'] = {{ TRILIO_ENCRYPTION }}
+    path: "/etc/horizon/local_settings.py"
+    regexp: "^TRILIO_ENCRYPTION_SUPPORT ="
+    line: TRILIO_ENCRYPTION_SUPPORT = {{ TRILIO_ENCRYPTION }}
 
 - name: Display local_settings.d path
   debug:


### PR DESCRIPTION
The encryption check box was missing while creating the workloads.
Failed due to the data format was not dictionary.
Switched to dictionary format for horizon settings.

Previous values:
```
-    regexp: '^OPENSTACK_ENCRYPTION_SUPPORT'
     line: OPENSTACK_ENCRYPTION_SUPPORT = {{ OPENSTACK_ENCRYPTION }}

-    regexp: '^TRILIO_ENCRYPTION_SUPPORT'
     line: TRILIO_ENCRYPTION_SUPPORT = {{ TRILIO_ENCRYPTION }}
```

Updated values:

```
-     regexp: "^HORIZON_CONFIG\\['OPENSTACK_ENCRYPTION_SUPPORT'\\] "
      line: HORIZON_CONFIG['OPENSTACK_ENCRYPTION_SUPPORT'] = {{ OPENSTACK_ENCRYPTION }}
  
-     regexp: "^HORIZON_CONFIG\\['TRILIO_ENCRYPTION_SUPPORT'\\] "
      line: HORIZON_CONFIG['TRILIO_ENCRYPTION_SUPPORT'] = {{ TRILIO_ENCRYPTION }}
```