### PR TITLE
fixing post_install tasks

### DIFF
--- a/ansible/roles/ansible-horizon-plugin/tasks/post_install.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/post_install.yml
@@ -1,29 +1,26 @@
 ---
 
-- name: Found location of trilio.pth file
-  shell: "{{virtual_env}} && {{ PYTHON_VERSION }} -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())'"
-  register: VENV_PKGLIB
-  when: ENV_PATH != "/usr"
+- block:
+  - name: Found location of trilio.pth file
+    shell: "{{virtual_env}} && {{ PYTHON_VERSION }} -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())'"
+    register: VENV_PKGLIB
 
-- set_fact:
-    TRILIO_FILE : "{{VENV_PKGLIB.stdout}}/trilio.pth"
-  when: ENV_PATH != "/usr"
+  - set_fact:
+      TRILIO_FILE : "{{VENV_PKGLIB.stdout}}/trilio.pth"
 
-- name: Found local packages library
-  shell: . /openstack/venvs/horizon*/bin/activate && echo $(/usr/bin/{{PYTHON_VERSION}} -c "import site, os; from os import path; p = [path_dir for path_dir in site.getsitepackages() if path.exists(os.path.join(path_dir, 'dashboards'))]; print(p[0]+'/')")
-  register: PACKAGELIB
-  when: ENV_PATH != "/usr"
+  - name: Found local packages library
+    shell: . /openstack/venvs/horizon*/bin/activate && echo $(/usr/bin/{{PYTHON_VERSION}} -c "import site, os; from os import path; p = [path_dir for path_dir in site.getsitepackages() if path.exists(os.path.join(path_dir, 'dashboards'))]; print(p[0]+'/')")
+    register: PACKAGELIB
 
-- set_fact:
-    PACKAGE_LIB : "{{PACKAGELIB.stdout}}"
-  when: ENV_PATH != "/usr"
+  - set_fact:
+      PACKAGE_LIB : "{{PACKAGELIB.stdout}}"
 
-- debug:
-    msg: "TRILIO_FILE :{{TRILIO_FILE}} --- PACKAGE_LIB {{PACKAGE_LIB}}"
-    verbosity: "{{ verbosity_level }}"
+  - debug:
+      msg: "TRILIO_FILE :{{TRILIO_FILE}} --- PACKAGE_LIB {{PACKAGE_LIB}}"
+      verbosity: "{{ verbosity_level }}"
 
-- name: Create trilio.pth file
-  shell: "echo {{ PACKAGE_LIB }} > {{ TRILIO_FILE }}"
+  - name: Create trilio.pth file
+    shell: "echo {{ PACKAGE_LIB }} > {{ TRILIO_FILE }}"
   when: ENV_PATH != "/usr"
 
 - block:


### PR DESCRIPTION
One task missed the condition "when: ENV_PATH != /usr"
Better to make a block and apply the condition to it.