### PR TITLE
Fix error in get_configs.py

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/files/get_configs.py
+++ b/ansible/roles/ansible-tvault-contego-extension/files/get_configs.py
@@ -12,7 +12,7 @@ for pid in pids:
                     if value == '--config-file':
                         config_files.append(value + '=' + fields[index + 1])
                     elif value.startswith(b'--config-file='):
-                        config_files.append(value)
+                        config_files.append(value.decode('utf-8'))
     except IOError: # proc has already terminated
         continue
 if not config_files:


### PR DESCRIPTION
Python3 treats "fields" items as byte objects, not strings.
Thus in the end you get this error: "TypeError: sequence item 0: expected str instance, bytes found"