### PR TITLE
Tvault 4858 Add RHOSP_16.2 Containers to build automation support Triliovault 4.2

### DIFF
--- a/redhat-director-scripts/docker/build_rhosp16_containers.sh
+++ b/redhat-director-scripts/docker/build_rhosp16_containers.sh
@@ -26,9 +26,9 @@ then
 base_dir="$current_dir"
 fi
 
-declare -a openstack_releases=("rhosp16" "rhosp16.1")
+declare -a openstack_releases=("rhosp16.1" "rhosp16.2")
 
-declare -a rhosp_releases=("16.0" "16.1")
+declare -a rhosp_releases=("16.1" "16.2")
 
 declare -a repositories=("registry.redhat.io/rhosp-rhel8/openstack-nova-compute" "registry.redhat.io/rhosp-rhel8/openstack-nova-api" "registry.redhat.io/rhosp-rhel8/openstack-horizon")
 


### PR DESCRIPTION
Add RHOSP_16.2 Containers to build automation support Triliovault 4.2

build_rhosp16_containers.sh script will add RHOSP16.1 and 16.2 containers