### PR TITLE
TVAULT-4858 ADD RHOSP 16.2 CONTAINER CREATION STEPS INTO TRILIO CFG SCRIPT

### DIFF
--- a/redhat-director-scripts/docker/build_rhosp16_containers.sh
+++ b/redhat-director-scripts/docker/build_rhosp16_containers.sh
@@ -26,9 +26,9 @@ then
 base_dir="$current_dir"
 fi
 
-declare -a openstack_releases=("rhosp16" "rhosp16.1")
+declare -a openstack_releases=("rhosp16.1" "rhosp16.2")
 
-declare -a rhosp_releases=("16.0" "16.1")
+declare -a rhosp_releases=("16.1" "16.2")
 
 declare -a repositories=("registry.redhat.io/rhosp-rhel8/openstack-nova-compute" "registry.redhat.io/rhosp-rhel8/openstack-nova-api" "registry.redhat.io/rhosp-rhel8/openstack-horizon")
 


### PR DESCRIPTION
Add RHOSP16.2 Containers creation code for support Triliovault 4.2 onward
Dropped support for RHOSP 16 from Triliovault 4.2 onward