### PR TITLE
Tvault 4869 [OSA-WALLABY] deployment was failing due to which python3 command is not working

### DIFF
--- a/ansible/roles/ansible-datamover-api/tasks/get_python.yml
+++ b/ansible/roles/ansible-datamover-api/tasks/get_python.yml
@@ -10,12 +10,12 @@
     verbosity: "{{verbosity_level}}"
 
 - name: find location when using python3
-  shell: which python3
+  shell: type -p python3
   register: python3
   when: PYTHON_VERSION=="python3"
 
 - name: find location when using python2
-  shell: which python
+  shell: type -p python
   register: python2
   when: PYTHON_VERSION=="python2"
 


### PR DESCRIPTION
While fetching the python location there is which python/which python3 shell command we were using into the file get_python.yml, but this was not working into the OSA-Wallaby Openstack DMAPI containers hence updating the command 
from 
`which python3 or which python`
 to 
 `type -p python3 or type -p python`