### PR TITLE
TVAULT-4883 & TL-33 Failed to deploy Horizon Plugin in OSA WALLABY

### DIFF
--- a/ansible/environments/group_vars/all/vars.yml
+++ b/ansible/environments/group_vars/all/vars.yml
@@ -71,7 +71,7 @@ ceph_backend_enabled: False
 
 ## Provide Horizon Virtual Env path from Horizon_container
 ## e.g. '/openstack/venvs/horizon-23.1.0'
-horizon_virtual_env: ''
+horizon_virtual_env: '/openstack/venvs/horizon*'
 
 #Set verbosity level and run playbooks with -vvv option to display custom debug messages
 verbosity_level: 3

--- a/ansible/environments/group_vars/all/vars.yml
+++ b/ansible/environments/group_vars/all/vars.yml
@@ -69,9 +69,9 @@ dmapi_workers: 16
 #True/False
 ceph_backend_enabled: False
 
-## Provide Horizon Container Virtual Env path
-## Default value of horizon_virtual_env is ' /openstack/venvs/horizon*'
-horizon_virtual_env: ' /openstack/venvs/horizon*'
+## Provide Horizon Virtual Env path from Horizon_container
+## e.g. '/openstack/venvs/horizon-23.1.0'
+horizon_virtual_env: ''
 
 #Set verbosity level and run playbooks with -vvv option to display custom debug messages
 verbosity_level: 3

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -36,11 +36,17 @@
   file: path=/tmp/sync_static.py state=absent
 
 - name: Get os_local_settings_path
-  shell: "find {{ horizon_virtual_env }} -type d -path /sys -prune -o -name '*local_settings.d' 2>/dev/null | grep -E 'openstack_dashboard|horizon'"
+  find:
+    paths: /openstack/venvs/
+    file_type: directory
+    use_regex: yes
+    patterns:
+      - '^.*?local_settings.d'
+    recurse: yes
   register: os_local_settings_path
 
 - name: HORIZON_CONFIG
-  shell: echo "HORIZON_CONFIG['customization_module'] = 'dashboards.overrides'" > `echo {{os_local_settings_path.stdout}} | cut -d ' ' -f1 |{ read trilio_setting_path ; echo $trilio_setting_path/_001_trilio_dashboard.py ; }`
+  shell: echo "HORIZON_CONFIG['customization_module'] = 'dashboards.overrides'" > `echo {{os_local_settings_path.files[0].path}} | cut -d ' ' -f1 |{ read trilio_setting_path ; echo $trilio_setting_path/_001_trilio_dashboard.py ; }`
   when:
     - os_local_settings_path != ""
 
@@ -68,7 +74,7 @@
 
 - name: Display local_settings.d path
   debug:
-    msg: "local_settings.d path: {{os_local_settings_path.stdout}}"
+    msg: "local_settings.d path: {{os_local_settings_path.files | map(attribute='path')}}"
     verbosity: "{{ verbosity_level }}"
   when:
     - os_local_settings_path != ""

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -41,7 +41,7 @@
     file_type: directory
     use_regex: yes
     patterns:
-      - '^.*local_settings.d$'
+      - '^.*?local_settings.(?:d)$'
     recurse: yes
   register: os_local_settings_path
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -37,7 +37,7 @@
 
 - name: Get os_local_settings_path
   find:
-    paths: /openstack/venvs/
+    paths: "{{ horizon_virtual_env }}/"
     file_type: directory
     use_regex: yes
     patterns: 
@@ -50,9 +50,9 @@
     loc_sett_path: "{{ os_local_settings_path.files| map(attribute='path')| list|join(',')}}"
     loc_sett_path_len: "{{ os_local_settings_path.files| map(attribute='path')| list|length}}"
 
-- name: Stop playbook execution when local_settings.d are multiples or not present
+- name: Stop playbook execution when local_settings.d not found or multiples
   fail:
-    msg: "Didn't found local_settings.d dir or more than one locals_settings.d directories are present."
+    msg: "Didn't find local_settings.d dir or more than one locals_settings.d directories found."
   when: (loc_sett_path_len|int == 0) or
         (loc_sett_path_len|int > 1)
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -41,7 +41,7 @@
     file_type: directory
     use_regex: yes
     patterns:
-      - '^.*?local_settings.d'
+      - '^.*local_settings.d$'
     recurse: yes
   register: os_local_settings_path
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -37,7 +37,7 @@
 
 - name: Get os_local_settings_path
   find:
-    paths: "{{ horizon_virtual_env }}/"
+    paths: "{{ horizon_virtual_env | dirname }}/"
     file_type: directory
     use_regex: yes
     patterns: 

--- a/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/collect_compress.yml
@@ -40,15 +40,27 @@
     paths: /openstack/venvs/
     file_type: directory
     use_regex: yes
-    patterns:
+    patterns: 
       - '^.*?local_settings.(?:d)$'
     recurse: yes
   register: os_local_settings_path
 
+- name: Find path & count of local_settings.d
+  set_fact:
+    loc_sett_path: "{{ os_local_settings_path.files| map(attribute='path')| list|join(',')}}"
+    loc_sett_path_len: "{{ os_local_settings_path.files| map(attribute='path')| list|length}}"
+
+- name: Stop playbook execution when local_settings.d are multiples or not present
+  fail:
+    msg: "Didn't found local_settings.d dir or more than one locals_settings.d directories are present."
+  when: (loc_sett_path_len|int == 0) or
+        (loc_sett_path_len|int > 1)
+
 - name: HORIZON_CONFIG
-  shell: echo "HORIZON_CONFIG['customization_module'] = 'dashboards.overrides'" > `echo {{os_local_settings_path.files[0].path}} | cut -d ' ' -f1 |{ read trilio_setting_path ; echo $trilio_setting_path/_001_trilio_dashboard.py ; }`
+  shell: "echo 'HORIZON_CONFIG['customization_module'] = 'dashboards.overrides'' > {{ loc_sett_path }}/_001_trilio_dashboard.py ;"
   when:
-    - os_local_settings_path != ""
+    - (os_local_settings_path != '')
+    - (loc_sett_path_len|int == 1)
 
 - set_fact: 
     OPENSTACK_ENCRYPTION: >
@@ -74,7 +86,7 @@
 
 - name: Display local_settings.d path
   debug:
-    msg: "local_settings.d path: {{os_local_settings_path.files | map(attribute='path')}}"
+    msg: "local_settings.d path: {{ os_local_settings_path.files | map(attribute='path') }}"
     verbosity: "{{ verbosity_level }}"
   when:
     - os_local_settings_path != ""

--- a/ansible/roles/ansible-horizon-plugin/tasks/find_manage_file.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/find_manage_file.yml
@@ -5,7 +5,7 @@
     paths: "{{ ENV_PATH }}"
     file_type: file
     use_regex: yes
-    patterns: "^.*?manage.(?:py)$"
+    patterns: "^.*manage.py$"
     recurse: yes
   register: output
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/find_manage_file.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/find_manage_file.yml
@@ -5,7 +5,7 @@
     paths: "{{ ENV_PATH }}"
     file_type: file
     use_regex: yes
-    patterns: "^.*manage.py$"
+    patterns: "^.*?manage.(?:py)$"
     recurse: yes
   register: output
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/find_manage_file.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/find_manage_file.yml
@@ -1,11 +1,17 @@
 ---
 
-- name: find location of manage.py
-  shell: "find {{ ENV_PATH }}  -name '*manage.py' | grep -E 'openstack-dashboard|horizon|bin'"
+- name: Find location of manage.py
+  find:
+    paths: "{{ ENV_PATH }}"
+    file_type: file
+    use_regex: yes
+    patterns: "^.*?manage.(?:py)$"
+    recurse: yes
   register: output
 
 - set_fact:
-    MANAGE_FILE : "{{output.stdout}}"
+    MANAGE_FILE: "{{ output.files[0].path}}"
+  when: output != ""
 
 - debug:
     msg: "manage.py is found at :{{MANAGE_FILE}}"

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -2,6 +2,27 @@
 #For Debian: apache2
 #For RHEL: httpd
 
+- name: Find out Horizon path
+  find:
+    paths: "{{ horizon_virtual_env[:17]}}"
+    file_type: directory
+    use_regex: yes
+    patterns:
+      - '^.*?horizon*'
+    recurse: no
+  register: horizon_path
+
+- name: Find Horizon directory path & count
+  set_fact:
+    horizon_dir_path: "{{ horizon_path.files| map(attribute='path')| list|join(',') }}"
+    horizon_dir_cnt: "{{ horizon_path.files| map(attribute='path')| list|length }}"
+
+- name: Stop playbook execution when Horizon directory not found or multiples
+  fail:
+          msg: "Please update the correct value of horizon_virtual_env present in /etc/openstack_deploy/user_tvault_vars.yml file"
+  when: (horizon_dir_cnt|int == 0) or
+        (horizon_dir_cnt|int > 1)
+
 - set_fact: WebServer=apache2
   when: ansible_distribution=="Ubuntu"
 
@@ -38,3 +59,4 @@
 - debug:
     msg: "{{HORIZON_PATH}}"
     verbosity: "{{verbosity_level}}"
+

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -2,9 +2,9 @@
 #For Debian: apache2
 #For RHEL: httpd
 
-- name: Find out Horizon path
-  find:
-    paths: "{{ horizon_virtual_env[:17]}}"
+- name: Find Horizon directory path
+  find: 
+    paths: "{{ horizon_virtual_env | dirname }}/"
     file_type: directory
     use_regex: yes
     patterns:
@@ -19,7 +19,7 @@
 
 - name: Stop playbook execution when Horizon directory not found or multiples
   fail:
-          msg: "Please update the correct value of horizon_virtual_env present in /etc/openstack_deploy/user_tvault_vars.yml file"
+    msg: "Please update the correct value of horizon_virtual_env present in user_tvault_vars.yml file"
   when: (horizon_dir_cnt|int == 0) or
         (horizon_dir_cnt|int > 1)
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -38,9 +38,3 @@
 - debug:
     msg: "{{HORIZON_PATH}}"
     verbosity: "{{verbosity_level}}"
-
-- name: Install the latest version of findutils
-  dnf:
-    name:
-      - findutils
-    state: latest

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -6,7 +6,7 @@
   find:
     paths: "{{ horizon_virtual_env | dirname }}/"
     file_type: directory
-    use_regex: yes
+    use_regex: no
     patterns:
       - "{{ horizon_virtual_env | basename }}"
     recurse: no

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -2,6 +2,25 @@
 #For Debian: apache2
 #For RHEL: httpd
 
+- name: Find Horizon directory path
+  find:
+    paths: "{{ horizon_virtual_env | dirname }}/"
+    file_type: directory
+    use_regex: yes
+    patterns:
+      - "{{ horizon_virtual_env | basename }}"
+    recurse: no
+  register: horizon_path
+
+- name: Find Horizon directory match count
+  set_fact:
+    horizon_dir_cnt: "{{ horizon_path.matched|int }}"
+
+- name: Stop playbook execution when Horizon directory not found or multiples
+  fail:
+    msg: "Pass full path of Horizon directory to horizon_virtual_env present in user_tvault_vars.yml file"
+  when: (horizon_dir_cnt != '1')
+
 - set_fact: WebServer=apache2
   when: ansible_distribution=="Ubuntu"
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -12,14 +12,10 @@
     recurse: no
   register: horizon_path
 
-- name: Find Horizon directory match count
-  set_fact:
-    horizon_dir_cnt: "{{ horizon_path.matched|int }}"
-
 - name: Stop playbook execution when Horizon directory not found or multiples
   fail:
     msg: "Pass full path of Horizon directory to horizon_virtual_env present in user_tvault_vars.yml file"
-  when: (horizon_dir_cnt != '1')
+  when: ({{ horizon_path.matched|int }} != 1)
 
 - set_fact: WebServer=apache2
   when: ansible_distribution=="Ubuntu"

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -2,27 +2,6 @@
 #For Debian: apache2
 #For RHEL: httpd
 
-- name: Find Horizon directory path
-  find: 
-    paths: "{{ horizon_virtual_env | dirname }}/"
-    file_type: directory
-    use_regex: yes
-    patterns:
-      - '^.*?horizon*'
-    recurse: no
-  register: horizon_path
-
-- name: Find Horizon directory path & count
-  set_fact:
-    horizon_dir_path: "{{ horizon_path.files| map(attribute='path')| list|join(',') }}"
-    horizon_dir_cnt: "{{ horizon_path.files| map(attribute='path')| list|length }}"
-
-- name: Stop playbook execution when Horizon directory not found or multiples
-  fail:
-    msg: "Please update the correct value of horizon_virtual_env present in user_tvault_vars.yml file"
-  when: (horizon_dir_cnt|int == 0) or
-        (horizon_dir_cnt|int > 1)
-
 - set_fact: WebServer=apache2
   when: ansible_distribution=="Ubuntu"
 

--- a/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
+++ b/ansible/roles/ansible-horizon-plugin/tasks/pre_tasks.yml
@@ -39,3 +39,8 @@
     msg: "{{HORIZON_PATH}}"
     verbosity: "{{verbosity_level}}"
 
+- name: Install the latest version of findutils
+  dnf:
+    name:
+      - findutils
+    state: latest


### PR DESCRIPTION
Added code changes to install the `findutils` package which is not present in the OSA Wallaby Horizon containers, which required to run some find commands which are present into the get_venv.yml