### PR TITLE
TVAULT-4869 Triliovault datamover api service deployment is failing due to which cmd is not working

### DIFF
--- a/ansible/roles/ansible-datamover-api/tasks/get_python.yml
+++ b/ansible/roles/ansible-datamover-api/tasks/get_python.yml
@@ -10,12 +10,12 @@
     verbosity: "{{verbosity_level}}"
 
 - name: find location when using python3
-  shell: which python3
+  shell: type -p python3
   register: python3
   when: PYTHON_VERSION=="python3"
 
 - name: find location when using python2
-  shell: which python
+  shell: type -p python
   register: python2
   when: PYTHON_VERSION=="python2"
 


### PR DESCRIPTION
`which` cmd is not working into the datamover API containers hence we have replaced the which cmd to `type -p `
