### PR TITLE
TVAULT-4930 Failed to deploy DMAPI service type -p command running was running in /bin/sh was wrong

### DIFF
--- a/ansible/roles/ansible-datamover-api/tasks/get_python.yml
+++ b/ansible/roles/ansible-datamover-api/tasks/get_python.yml
@@ -10,12 +10,12 @@
     verbosity: "{{verbosity_level}}"
 
 - name: find location when using python3
-  shell: type -p python3
+  command: /bin/bash -c "type -p python3"
   register: python3
   when: PYTHON_VERSION=="python3"
 
 - name: find location when using python2
-  shell: type -p python
+  command: /bin/bash -c "type -p python"
   register: python2
   when: PYTHON_VERSION=="python2"
 


### PR DESCRIPTION
To fetch the current running python path we were running the _type -p python<version>_ with Ansible shell module.

Shell modules run the commands under /bin/sh ansible was activating the /bin/sh shell if we run the _type -p python<version>_

It was showing the **-p not found** and instead of the path of python comes with the **_python3 is_** 

Due to this  [TASK] find location when using python<version>  was failing

Updated code to check the currently which python were uses bash /bin/bash 

```
grroot@controller:~# lxc-ls | grep dmapi
controller_dmapi_container-6fff6daf          controller_galera_container-a868fba1
root@controller:~# lxc-attach -n controller_dmapi_container-6fff6daf
root@controller-dmapi-container-6fff6daf:~# type -p python3
/usr/bin/python3
root@controller-dmapi-container-6fff6daf:~# /bin/sh
# type -p python3
-p: not found
python3 is /usr/bin/python3
#
root@controller-dmapi-container-6fff6daf:~# /bin/bash
root@controller-dmapi-container-6fff6daf:~# type -p python3
/usr/bin/python3
root@controller-dmapi-container-6fff6daf:~#
```