### PR TITLE
TVAULT-5096: running the container with specific group fails encrypted snapshot creation

### DIFF
--- a/openstack-helm/triliovault/values.yaml
+++ b/openstack-helm/triliovault/values.yaml
@@ -95,27 +95,22 @@ pod:
           readOnlyRootFilesystem: false
           privileged: true
           runAsUser: 42424
-          runAsGroup: 42424
         triliovault_wlm_api:
           readOnlyRootFilesystem: false
           privileged: true
           runAsUser: 42424
-          runAsGroup: 42424
         triliovault_wlm_scheduler:
           readOnlyRootFilesystem: false
           privileged: true
           runAsUser: 42424
-          runAsGroup: 42424
         triliovault_wlm_cron:
           readOnlyRootFilesystem: false
           allowPrivilegeEscalation: false
           runAsUser: 42424
-          runAsGroup: 42424
         triliovault_wlm_workloads:
           readOnlyRootFilesystem: false
           privileged: true
           runAsUser: 42424
-          runAsGroup: 42424
         triliovault_wlm_init:
           readOnlyRootFilesystem: false
           runAsUser: 0


### PR DESCRIPTION
- The containers are now running with nova user with correct groups:
```
root@moskautomation1:/opt/triliovault-cfg-scripts/openstack-helm/triliovault# kubectl exec -it triliovault-datamover-openstack-compute-node-fzqrb -- id
Defaulted container "triliovault-datamover" out of: triliovault-datamover, init (init), triliovault-datamover-init (init), ceph-keyring-placement-triliovault (init)
uid=42424(nova) gid=42424(nova) groups=42424(nova),6(disk),113(kvm),115(libvirt)
root@moskautomation1:/opt/triliovault-cfg-scripts/openstack-helm/triliovault#
```

- Encrypted Snapshots and restores are successful 