### PR TITLE
TVAULT-5010 Cleanup contego venv dependency from the datamover packages

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -56,7 +56,6 @@
   yum:
      update_cache: yes
      name:
-        - puppet-triliovault
         - tvault-contego
      state: latest
   when: PYTHON_VERSION=="python2"
@@ -65,7 +64,6 @@
   yum:
      update_cache: yes
      name:
-        - puppet-triliovault
         - python3-tvault-contego
      state: latest
   when: PYTHON_VERSION=="python3"

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_ubuntu.yml
@@ -40,14 +40,6 @@
     name: "rbd"
     state: "present"
 
-- name: Download contego virtenv deb package
-  shell: |
-          curl -Og6 http://{{ IP_ADDRESS }}:{{ PORT_NO }}/deb-repo/deb-repo/tvault-contego-extension_{{ TVAULT_PACKAGE_VERSION }}_all.deb
-          dpkg --configure -a && apt-get -o Dpkg::Options::="--force-confold" install ./tvault-contego-extension_{{TVAULT_PACKAGE_VERSION}}_all.deb -y
-          rm -rf ./tvault-contego-extension_{{ TVAULT_PACKAGE_VERSION }}_all.deb
-
-- debug : msg="curl -Og6 http://{{IP_ADDRESS}}:{{ PORT_NO }}/deb-repo/deb-repo/tvault-contego-extension_{{TVAULT_PACKAGE_VERSION}}_all.deb" verbosity={{ verbosity_level }}
-
 - name: install tvault-contego deb package when using python2
   shell: |
           curl -Og6 http://{{ IP_ADDRESS }}:{{ PORT_NO }}/deb-repo/deb-repo/tvault-contego_{{ TVAULT_PACKAGE_VERSION  }}_all.deb

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/post_install.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/post_install.yml
@@ -1,7 +1,4 @@
 ---
-- name: Removing Contego from virtual environment
-  file: path=/home/tvault/.virtenv/lib/python2.7/site-packages/contego state=absent
-
 - import_tasks: get_venv.yml
 
 - name: Remove tvault-contego-virtenv.tar.gz

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/uninstall_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/uninstall_rhel.yml
@@ -15,7 +15,6 @@
      name:
         - python-s3fuse-plugin-cent7
         - tvault-contego
-        - puppet-triliovault
      state: absent
   when: PYTHON_VERSION=="python2"
 
@@ -25,7 +24,6 @@
         - "centos-release-openstack-{{OPENSTACK_DIST | lower}}"
         - python3-s3fuse-plugin
         - python3-tvault-contego
-        - puppet-triliovault
      state: absent
   when: PYTHON_VERSION=="python3"
 

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/uninstall_ubuntu.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/uninstall_ubuntu.yml
@@ -7,13 +7,6 @@
   service: name=tvault-contego state=stopped enabled=no
   ignore_errors: yes
 
-- name: uninstall contego deb package
-  apt:
-     name: contego
-     state: absent
-     allow_unauthenticated: yes
-     purge: yes
-
 - name: uninstall tvault-contego deb package when using python2
   apt:
      name:


### PR DESCRIPTION
Code cleanup.

Not required to deploy the contego & puppet-triliovault packages.