### PR TITLE
TVAULT-5321 Tvault 5.0 Deployment Failed due to deprecated option log_config uses instead of log_config_append

### DIFF
--- a/ansible/roles/ansible-datamover-api/tasks/db_setup_ussuri.yml
+++ b/ansible/roles/ansible-datamover-api/tasks/db_setup_ussuri.yml
@@ -2,13 +2,13 @@
 - name: Setup Database Service (MariaDB)
   delegate_to: "{{_oslodb_setup_host }}"
   block:
-    - name: Ussuri | Create database for service Ussuri
+    - name: Create database for service
       mysql_db:
         name: "{{ item.name }}"
       loop: "{{ _oslodb_databases }}"
       no_log: true
 
-    - name:  Ussuri | Grant access to the database for the service
+    - name: Grant access to the database for the service
       mysql_user:
         name: "{{ item.1.username }}"
         password: "{{ item.1.password }}"

--- a/ansible/roles/ansible-datamover-api/tasks/db_setup_victoria.yml
+++ b/ansible/roles/ansible-datamover-api/tasks/db_setup_victoria.yml
@@ -4,7 +4,7 @@
   vars:
     ansible_python_interpreter: "{{ _oslodb_ansible_python_interpreter }}"
   block:
-    - name: Victoria | Create database for service
+    - name: Create database
       mysql_db:
         name: "{{ item.name }}"
         login_host: "{{ _oslodb_setup_endpoint | default(omit) }}"
@@ -12,7 +12,7 @@
       loop: "{{ _oslodb_databases }}"
       no_log: true
 
-    - name: Victoria | Grant access to the database for the service
+    - name: Grant access to the database for the service
       mysql_user:
         name: "{{ item.1.username }}"
         password: "{{ item.1.password }}"

--- a/ansible/roles/ansible-datamover-api/templates/datamover_url
+++ b/ansible/roles/ansible-datamover-api/templates/datamover_url
@@ -7,9 +7,7 @@ my_ip = {{container_address}}
 transport_url: {{ dmapi_oslomsg_rpc_transport }}://{% for host in dmapi_oslomsg_rpc_servers.split(',') %}{{ dmapi_oslomsg_rpc_userid }}:{{ dmapi_oslomsg_rpc_password }}@{{ host }}:{{ dmapi_oslomsg_rpc_port }}{% if not loop.last %},{% else %}/{{ dmapi_oslomsg_rpc_vhost }}{% if dmapi_oslomsg_rpc_use_ssl | bool %}?ssl=1&ssl_version={{ dmapi_oslomsg_rpc_ssl_version }}&ssl_ca_file={{ dmapi_oslomsg_rpc_ssl_ca_file }}{% else %}?ssl=0{% endif %}{% endif %}{% endfor %}
 
 
-log_dir = {{ DMAPI_LOG_DIR }}
-log_file = {{ DMAPI_LOG_FILE }}
-log_config = {{ DMAPI_LOG_CONF }}
+log_config_append = {{ DMAPI_LOG_CONF }}
 
 
 [database]

--- a/ansible/roles/ansible-tvault-contego-extension/templates/tvault-contego.conf.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/tvault-contego.conf.j2
@@ -37,11 +37,7 @@ vault_s3_ssl_cert =
 vault_data_directory_old = {{TRILIOVAULT_MNT_DIR_OLD}}
 vault_data_directory = {{TRILIOVAULT_MNT_DIR}}
 
-log_dir = {{ TRILIOVAULT_LOG_DIR }}
-log_file = {{ DATAMOVER_LOG_FILE }}
-log_config = {{ DATAMOVER_LOG_CONF }}
-
-##log_file = /var/log/tvault-contego/tvault-contego.log
+log_config_append = {{ DATAMOVER_LOG_CONF }}
 
 
 

--- a/ansible/roles/ansible-tvault-contego-extension/templates/tvault-object-store.conf.j2
+++ b/ansible/roles/ansible-tvault-contego-extension/templates/tvault-object-store.conf.j2
@@ -23,11 +23,7 @@ vault_s3_ssl_cert =
 vault_data_directory_old = {{TRILIOVAULT_MNT_DIR_OLD}}
 vault_data_directory = {{TRILIOVAULT_MNT_DIR}}
 
-log_dir = {{ TRILIOVAULT_LOG_DIR }}
-log_file = {{ TRILIOVAULT_LOG_DIR }}/tvault-object-store.log
-log_config = {{ DATAMOVER_LOG_CONF }}
-
-##log_file = /var/log/tvault-object-store/tvault-object-store.log
+log_config_append = {{ DATAMOVER_LOG_CONF }}
 
 debug = False
 verbose = True

--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-object-store.conf.j2
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-object-store.conf.j2
@@ -42,7 +42,7 @@ vault_data_directory = {{ triliovault_mnt_dir }}
 
 log_file = {{ OBJECT_STORE_LOG_FILE }}
 debug = False
-log_config = {{ OBJECT_STORE_LOG_CFG }}
+log_config_append = {{ OBJECT_STORE_LOG_CFG }}
 
 verbose = True
 vault_s3_max_pool_connections = 500

--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-wlm.conf.j2
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-wlm.conf.j2
@@ -1,7 +1,5 @@
 [DEFAULT]
-log_dir = {{ triliovault_log_dir }}
-log_file = {{ wlm_log_file }}
-log_config = {{ wlm_log_cfg }}
+log_config_append = {{ wlm_log_cfg }}
 
 use_syslog = False
 use_stderr = False
@@ -20,8 +18,6 @@ sql_connection = mysql+pymysql://{{ wlm_galera_user }}:{{ wlm_galera_password }}
 verbose = True
 osapi_workloads_listen_port = {{ osapi_workloads_listen_port }}
 
-#Not required if you are using log_config
-#debug=False
 
 ##OS Details
 cloud_admin_user_id = {{ cloud_admin_user_id }}


### PR DESCRIPTION
In the configuration file under the default section log_config option has been used, it's deprecated.
So we need to use log_config_append instead of log_config