### PR TITLE
updated triliovault_workloadmgr_keystone_user

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
+++ b/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
@@ -264,7 +264,7 @@ triliovault_ks_services:
     triliovault_keystone_user: "triliovault"  
 
 triliovault_datamover_keystone_user: "dmapi"	
-triliovault_workloadmgr_keystone_user: "triliovault"	
+triliovault_workloadmgr_keystone_user: "workloadmgr"	
 
 triliovault_ks_users:
   - project: "service"


### PR DESCRIPTION
Updated the Triliovault workloadmgr keystone user use '**workloadmgr**' instead of '**triliovault**'