### PR TITLE
TVAULT-5336: Mysql connection issue if the driver is not set to pymysql

### DIFF
--- a/ansible/environments/group_vars/all/vars.yml
+++ b/ansible/environments/group_vars/all/vars.yml
@@ -62,18 +62,20 @@ multi_ip_nfs_enabled: False
 ##True/False
 S3: False
 
+#######################################
+#### S3 Specific Backend Configurations
+#######################################
 VAULT_S3_ACCESS_KEY: sample_s3_access_key
 VAULT_S3_SECRET_ACCESS_KEY: sample_s3_secret_access_key
-
 VAULT_S3_REGION_NAME: sample_s3_region_name
 VAULT_S3_BUCKET: sample_s3_bucket
 
-VAULT_S3_SIGNATURE_VERSION:
-VAULT_S3_AUTH_VERSION:
+## Do not change below 2 params if not sure
+#VAULT_S3_SIGNATURE_VERSION: default
+#VAULT_S3_AUTH_VERSION: DEFAULT
 
-#### S3 Specific Backend Configurations
 #### Provide one of follwoing two values in s3_type variable, string's case should be match
-#Amazon/Other_S3_Compatible
+# Amazon/Other_S3_Compatible
 s3_type: sample_s3_type
 
 #### Required field(s) for all S3 backends except Amazon

--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/tasks/triliovault_db_sync.yml
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/tasks/triliovault_db_sync.yml
@@ -1,3 +1,4 @@
 ---
 - name: Populate workloadmgr database
   command: alembic --config {{ wlm_cfg }} upgrade head
+  run_once: True

--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-object-store.conf.j2
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-object-store.conf.j2
@@ -17,16 +17,16 @@ vault_s3_endpoint_url = {{ VAULT_S3_ENDPOINT_URL }}
 vault_s3_endpoint_url =
 {% endif %}
 
-{% if VAULT_S3_SIGNATURE_VERSION != "" %}
+{% if VAULT_S3_SIGNATURE_VERSION is defined and VAULT_S3_SIGNATURE_VERSION != "" %}
 vault_s3_signature_version = {{ VAULT_S3_SIGNATURE_VERSION }}
 {% else %}
-vault_s3_signature_version =
+vault_s3_signature_version = default
 {% endif %}
 
-{% if VAULT_S3_AUTH_VERSION != "" %}
+{% if VAULT_S3_AUTH_VERSION is defined and VAULT_S3_AUTH_VERSION != "" %}
 vault_s3_auth_version = {{ VAULT_S3_AUTH_VERSION }}
 {% else %}
-vault_s3_auth_version =
+vault_s3_auth_version = DEFAULT
 {% endif %}
 
 {% if VAULT_S3_SSL_CERT != "" %}

--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-wlm.conf.j2
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-wlm.conf.j2
@@ -98,7 +98,11 @@ vault_s3_support_empty_dir = False
 
 vault_storage_type = s3
 vault_storage_nfs_export = TrilioVault
+{% if VAULT_S3_AUTH_VERSION is defined and VAULT_S3_AUTH_VERSION != "" %}
 vault_s3_auth_version = {{ VAULT_S3_AUTH_VERSION }}
+{% else %}
+vault_s3_auth_version = DEFAULT
+{% endif %}
 vault_s3_access_key_id = {{ VAULT_S3_ACCESS_KEY }}
 vault_s3_secret_access_key = {{ VAULT_S3_SECRET_ACCESS_KEY }}
 
@@ -106,7 +110,12 @@ vault_s3_region_name = {{ VAULT_S3_REGION_NAME }}
 vault_s3_bucket = {{ VAULT_S3_BUCKET }}
 vault_s3_endpoint_url = {{VAULT_S3_ENDPOINT_URL}}
 
-vault_s3_signature_version = {{VAULT_S3_SIGNATURE_VERSION}}
+{% if VAULT_S3_SIGNATURE_VERSION is defined and VAULT_S3_SIGNATURE_VERSION != "" %}
+vault_s3_signature_version = {{ VAULT_S3_SIGNATURE_VERSION }}
+{% else %}
+vault_s3_signature_version = default
+{% endif %}
+
 vault_s3_ssl = {{VAULT_S3_SECURE}}
 
 vault_enable_threadpool = True
@@ -191,7 +200,7 @@ script_location = /usr/share/workloadmgr/migrate_repo
 version_locations = /usr/share/workloadmgr/migrate_repo/versions
 
 {% endif %}
-sqlalchemy.url = mysql://{{ wlm_galera_user }}:{{ wlm_galera_password }}@{{ wlm_galera_address }}/{{ wlm_galera_database }}?charset=utf8{% if wlm_galera_use_ssl | bool %}&ssl_ca={{ wlm_galera_ssl_ca_cert }}{% endif %}
+sqlalchemy.url = mysql+pymysql://{{ wlm_galera_user }}:{{ wlm_galera_password }}@{{ wlm_galera_address }}/{{ wlm_galera_database }}?charset=utf8{% if wlm_galera_use_ssl | bool %}&ssl_ca={{ wlm_galera_ssl_ca_cert }}{% endif %}
 
 
 [filesearch]


### PR DESCRIPTION
- Additional fix: In HA env, db sync cmd should run only once, running on all nodes will fail.
- Additional fix: Default values are set for S3 signature and auth versions