### PR TITLE
TVAULT-5338 RPM Based S3 Fuse Plugin Name was miss-spelled in install task

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/install_rhel.yml
@@ -65,10 +65,10 @@
       - python3-tvault-contego
     state: latest
 
-- name: Install python3-s3-fuse-plugin packages
+- name: Install python3-s3fuse-plugin packages
   package:
     name:
-      - python3-s3-fuse-plugin
+      - python3-s3fuse-plugin
     state: latest
 
 - name: Remove recently installed openstack-{{OPENSTACK_DIST}} repo


### PR DESCRIPTION
RPM package of S3 fuse plugin was miss-spelled in install task