### PR TITLE
updated workloadmgrclient and contegoclient package name

### DIFF
--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/tasks/install-centos.yml
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/tasks/install-centos.yml
@@ -89,8 +89,8 @@
   package:
     name: 
       - workloadmgr
-      - python3-workloadmgrclient
-      - python3-contegoclient
+      - python3-workloadmgrclient-el8
+      - python3-contegoclient-el8
       - python3-s3fuse-plugin
     state: latest
 


### PR DESCRIPTION
We are explicitly installing the workloadmgrclient and contegoclient packages under the wlm container
