### PR TITLE
TVAULT-5330 : Rename MOSK container tags to keep them in sync with other container tags

### DIFF
--- a/openstack-helm/triliovault/values.yaml
+++ b/openstack-helm/triliovault/values.yaml
@@ -51,15 +51,15 @@ images:
     ks_endpoints: docker.io/openstackhelm/heat:ocata-ubuntu_xenial
     dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
     image_repo_sync: docker.io/docker:17.07.0
-    triliovault_wlm_cloud_trust: docker.io/trilio/triliovault-wlm-helm:5.0.0-train-ubuntu_bionic
-    triliovault_wlm_api: docker.io/trilio/triliovault-wlm-helm:5.0.0-train-ubuntu_bionic
-    triliovault_wlm_cron: docker.io/trilio/triliovault-wlm-helm:5.0.0-train-ubuntu_bionic
-    triliovault_wlm_scheduler: docker.io/trilio/triliovault-wlm-helm:5.0.0-train-ubuntu_bionic
-    triliovault_wlm_workloads: docker.io/trilio/triliovault-wlm-helm:5.0.0-train-ubuntu_bionic
-    triliovault_datamover: docker.io/trilio/triliovault-datamover-helm:5.0.0-train-ubuntu_bionic
-    triliovault_datamover_api: docker.io/trilio/triliovault-datamover-api-helm:5.0.0-train-ubuntu_bionic
-    triliovault_datamover_db_sync: docker.io/trilio/triliovault-datamover-api-helm:5.0.0-train-ubuntu_bionic
-    triliovault_wlm_db_sync: docker.io/trilio/triliovault-wlm-helm:5.0.0-train-ubuntu_bionic
+    triliovault_wlm_cloud_trust: docker.io/trilio/trilio-wlm-helm:5.0.0-train-ubuntu_bionic
+    triliovault_wlm_api: docker.io/trilio/trilio-wlm-helm:5.0.0-train-ubuntu_bionic
+    triliovault_wlm_cron: docker.io/trilio/trilio-wlm-helm:5.0.0-train-ubuntu_bionic
+    triliovault_wlm_scheduler: docker.io/trilio/trilio-wlm-helm:5.0.0-train-ubuntu_bionic
+    triliovault_wlm_workloads: docker.io/trilio/trilio-wlm-helm:5.0.0-train-ubuntu_bionic
+    triliovault_datamover: docker.io/trilio/trilio-datamover-helm:5.0.0-train-ubuntu_bionic
+    triliovault_datamover_api: docker.io/trilio/trilio-datamover-api-helm:5.0.0-train-ubuntu_bionic
+    triliovault_datamover_db_sync: docker.io/trilio/trilio-datamover-api-helm:5.0.0-train-ubuntu_bionic
+    triliovault_wlm_db_sync: docker.io/trilio/trilio-wlm-helm:5.0.0-train-ubuntu_bionic
   pull_policy: "IfNotPresent"
   local_registry:
     active: false

--- a/openstack-helm/triliovault/values_overrides/train-ubuntu_bionic.yaml
+++ b/openstack-helm/triliovault/values_overrides/train-ubuntu_bionic.yaml
@@ -10,13 +10,13 @@ images:
     ks_endpoints: docker.io/openstackhelm/heat:train-ubuntu_bionic
     dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
     image_repo_sync: docker.io/docker:17.07.0
-    triliovault_wlm_cloud_trust: docker.io/trilio/triliovault-wlm-helm:dev11-train-ubuntu_bionic
-    triliovault_wlm_api: docker.io/trilio/triliovault-wlm-helm:dev11-train-ubuntu_bionic
-    triliovault_wlm_cron: docker.io/trilio/triliovault-wlm-helm:dev11-train-ubuntu_bionic
-    triliovault_wlm_scheduler: docker.io/trilio/triliovault-wlm-helm:dev11-train-ubuntu_bionic
-    triliovault_wlm_workloads: docker.io/trilio/triliovault-wlm-helm:dev11-train-ubuntu_bionic
-    triliovault_wlm_db_sync: docker.io/trilio/triliovault-wlm-helm:dev11-train-ubuntu_bionic
-    triliovault_datamover: docker.io/trilio/triliovault-datamover-helm:dev10-train-ubuntu_bionic
-    triliovault_datamover_api: docker.io/trilio/triliovault-datamover-api-helm:dev2-train-ubuntu_bionic
-    triliovault_datamover_db_sync: docker.io/trilio/triliovault-datamover-api-helm:dev2-train-ubuntu_bionic
+    triliovault_wlm_cloud_trust: docker.io/trilio/trilio-wlm-helm:dev11-train-ubuntu_bionic
+    triliovault_wlm_api: docker.io/trilio/trilio-wlm-helm:dev11-train-ubuntu_bionic
+    triliovault_wlm_cron: docker.io/trilio/trilio-wlm-helm:dev11-train-ubuntu_bionic
+    triliovault_wlm_scheduler: docker.io/trilio/trilio-wlm-helm:dev11-train-ubuntu_bionic
+    triliovault_wlm_workloads: docker.io/trilio/trilio-wlm-helm:dev11-train-ubuntu_bionic
+    triliovault_wlm_db_sync: docker.io/trilio/trilio-wlm-helm:dev11-train-ubuntu_bionic
+    triliovault_datamover: docker.io/trilio/trilio-datamover-helm:dev10-train-ubuntu_bionic
+    triliovault_datamover_api: docker.io/trilio/trilio-datamover-api-helm:dev2-train-ubuntu_bionic
+    triliovault_datamover_db_sync: docker.io/trilio/trilio-datamover-api-helm:dev2-train-ubuntu_bionic
 ...

--- a/openstack-helm/triliovault/values_overrides/victoria-ubuntu_focal.yaml
+++ b/openstack-helm/triliovault/values_overrides/victoria-ubuntu_focal.yaml
@@ -10,12 +10,12 @@ images:
     ks_endpoints: docker.io/openstackhelm/heat:victoria-ubuntu_focal
     dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
     image_repo_sync: docker.io/docker:17.07.0
-    triliovault_wlm_cloud_trust: docker.io/trilio/triliovault-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_wlm_api: docker.io/trilio/triliovault-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_wlm_cron: docker.io/trilio/triliovault-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_wlm_scheduler: docker.io/trilio/triliovault-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_wlm_workloads: docker.io/trilio/triliovault-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_wlm_db_sync: docker.io/trilio/triliovault-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_datamover: docker.io/trilio/triliovault-datamover-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_datamover_api: docker.io/trilio/triliovault-datamover-api-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
-    triliovault_datamover_db_sync: docker.io/trilio/triliovault-datamover-api-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_wlm_cloud_trust: docker.io/trilio/trilio-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_wlm_api: docker.io/trilio/trilio-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_wlm_cron: docker.io/trilio/trilio-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_wlm_scheduler: docker.io/trilio/trilio-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_wlm_workloads: docker.io/trilio/trilio-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_wlm_db_sync: docker.io/trilio/trilio-wlm-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_datamover: docker.io/trilio/trilio-datamover-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_datamover_api: docker.io/trilio/trilio-datamover-api-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal
+    triliovault_datamover_db_sync: docker.io/trilio/trilio-datamover-api-helm:5.0.6-dev-stable-2-victoria-ubuntu_focal


### PR DESCRIPTION
TVAULT-5330 : Rename MOSK container tags to keep them in sync with other container tags

_**Note** : PR will be merged before triggering of next 5.0 build so that ongoing sanity runs don't get impacted._