### PR TITLE
TVAULT-5420 mount dir should be insync with 4.2 build

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/defaults/main.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/defaults/main.yml
@@ -4,7 +4,7 @@ trilio_apt_repo_file_path: /etc/apt/sources.list.d/trilio.list
 trilio_yum_repo_file_path: /etc/yum.repos.d/trilio.repo
 
 ## Required Directories
-TRILIOVAULT_MNT_DIR: "/var/trilio/triliovault-mounts"
+TRILIOVAULT_MNT_DIR: "/var/triliovault-mounts"
 TRILIOVAULT_OBJ_STR: "/etc/triliovault-object-store"
 
 TRILIOVAULT_LOG_DIR: "/var/log/triliovault"

--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/defaults/main.yml
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/defaults/main.yml
@@ -171,7 +171,7 @@ auth_version: v3
 keystone_auth_version: 3
 
 ## Required Directories
-triliovault_mnt_dir: "/var/trilio/triliovault-mounts"
+triliovault_mnt_dir: "/var/triliovault-mounts"
 triliovault_obj_str: "/etc/triliovault-object-store"
 
 triliovault_log_dir: "/var/log/triliovault"


### PR DESCRIPTION
corrected the triliovault mount dir from **/var/trilio/triliovault-mounts** to **/var/triliovault-mounts**

