### PR TITLE
TVAULT-5328 Failed ansible-tvault-contego-extension : create trilio.filters for mount and unmount task

### DIFF
--- a/ansible/environments/group_vars/all/vars.yml
+++ b/ansible/environments/group_vars/all/vars.yml
@@ -73,6 +73,10 @@ ceph_backend_enabled: False
 ## e.g. '/openstack/venvs/horizon-23.1.0'
 horizon_virtual_env: '/openstack/venvs/horizon*'
 
+## If more than one Nova Virtual Env on Compute Node(s)
+### then specify Nova Virtual Env as e.g. 'openstack/venvs/nova-23.2.0'
+nova_virtual_env: '/openstack/venvs/nova*'
+
 #Set verbosity level and run playbooks with -vvv option to display custom debug messages
 verbosity_level: 3
 

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
@@ -1,5 +1,5 @@
 - name: Get nova venv path
-  shell: echo /openstack/venvs/nova*
+  shell: echo {{ nova_virtual_env }}
   register: venv_path
 
 - set_fact: virtual_env_path={{venv_path.stdout}}


### PR DESCRIPTION
Need to specify the **nova_virtual_env** under _/etc/openstack_deploy/user_tvault_vars.yml_ if more than one nova virtual environment is present on compute node.
The  default value of **nova_virtual_env** is '/openstack/venvs/nova*'