### PR TITLE
run once the task of cloud admin trust creation 

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault/tasks/deploy.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/deploy.yml
@@ -21,3 +21,4 @@
 
 - include_tasks: wlm_cloud_trust.yml
   when: inventory_hostname in groups[triliovault_wlm_api_group]
+  run_once: True


### PR DESCRIPTION
**Cloud Admin Trust Creation Should Run only once.**
