### PR TITLE
TVAULT-5326 dmapi_all also includes bare metal hosts on non LXC deployment

### DIFF
--- a/ansible/main-install.yml
+++ b/ansible/main-install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Installation and setup of dmapi conatiner
-  hosts: dmapi_all
+  hosts: tvault-dmapi_all 
   gather_facts: "{{ osa_gather_facts | default(True) }}"
   user: root
   environment: "{{ deployment_environment_variables | default({}) }}"


### PR DESCRIPTION
Triliovautl-datamover-api hostname updated the reason behind it, if we run the cfg script then the deployment of the dmapi service was held on bare metal server along with dmapi container.