### PR TITLE
improvement TVAULT-5328 Nova virtual env with venv_tag

### DIFF
--- a/ansible/environments/group_vars/all/vars.yml
+++ b/ansible/environments/group_vars/all/vars.yml
@@ -73,9 +73,11 @@ ceph_backend_enabled: False
 ## e.g. '/openstack/venvs/horizon-23.1.0'
 horizon_virtual_env: '/openstack/venvs/horizon*'
 
-## If more than one Nova Virtual Env on Compute Node(s)
-### then specify Nova Virtual Env as e.g. 'openstack/venvs/nova-23.2.0'
-nova_virtual_env: '/openstack/venvs/nova*'
+## When More Than One Nova Virtual Env. On Compute Node(s) and
+## User Wants To Specify Specific Nova Virtual Env. From Existing
+## Then Only Uncomment the var nova_virtual_env and pass value like 'openstack/venvs/nova-23.2.0'
+
+#nova_virtual_env: 'openstack/venvs/nova-23.2.0'
 
 #Set verbosity level and run playbooks with -vvv option to display custom debug messages
 verbosity_level: 3

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
@@ -1,15 +1,22 @@
 
 - name: Get nova venv path
   shell: echo /openstack/venvs/nova-{{ venv_tag }}
-  register: venv_path
+  register: pre_check_nova
   when: nova_virtual_env is undefined
 
 - name: Get nova venv path when nova_virtual_env is passed
   shell: echo {{ nova_virtual_env }}
-  register: venv_path
+  register: pre_check_nova
   when: nova_virtual_env is defined
 
-- set_fact: virtual_env_path={{venv_path.stdout}}
+- name: Get stats nova virtual path
+  stat:
+    path: "{{ pre_check_nova.stdout }}"
+  register: check_venv_path
+   
+- set_fact: virtual_env_path={{pre_check_nova.stdout}}
+  when:
+    - check_venv_path.stat.exists == True 
 
 - set_fact:
     virtual_env: ". {{virtual_env_path}}/bin/activate"

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
@@ -1,44 +1,24 @@
 
-- set_fact:
-    sys_nova_pth: /openstack/venvs/nova-{{ venv_tag }}
-
-- name: Check stat default nova virt path
-  stat:
-    path: "{{ sys_nova_pth }}"
-  register: chk_def_pth
-  when: nova_virtual_env is undefined
-   
-- name: Check stat user provided nova virt path
-  stat:
-    path: "{{ nova_virtual_env }}"
-  register: chk_usr_pth
-  when: nova_virtual_env is defined
-
-- name: Failed when nova virt env not found
-  fail: 
-    msg: "Anisble Failed Cause Path {{ sys_nova_pth }} Not Found"
-  when: >
-        ( nova_virtual_env is undefined ) and
-        ( chk_def_pth.stat.exists == false )
-
-- name: Failed when nova virt env not found
-  fail: 
-    msg: "Anisble Failed Cause Path {{ nova_virtual_env }} Not Found"
-  when: > 
-        ( nova_virtual_env is defined ) and
-        ( chk_usr_pth.stat.exists == false )
-
 - set_fact: 
-    virtual_env_path: "{{ sys_nova_pth }}"
+    virtual_env_path: "/openstack/venvs/nova-{{ venv_tag }}"
   when: >
-        ( nova_virtual_env is undefined ) and
-        ( chk_def_pth.stat.exists == true )
+        ( nova_virtual_env is undefined )
 
 - set_fact: 
     virtual_env_path: "{{ nova_virtual_env }}"
   when: > 
-        ( nova_virtual_env is defined ) and
-        ( chk_usr_pth.stat.exists == true )
+        ( nova_virtual_env is defined )
+
+- name: Check stat virtual env path
+  stat:
+    path: "{{ virtual_env_path }}"
+  register: chk_nova_pth
+
+- name: Failed when nova virt env not found
+  fail: 
+    msg: "Anisble Failed Cause Path {{ virtual_env_path }} Not Found"
+  when: > 
+        ( chk_nova_pth.stat.exists == false )
 
 - set_fact:
     virtual_env: ". {{virtual_env_path}}/bin/activate"

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
@@ -2,16 +2,6 @@
 - set_fact:
     sys_nova_pth: /openstack/venvs/nova-{{ venv_tag }}
 
-- name: Get nova venv path
-  shell: echo {{ sys_nova_pth }}
-  register: pre_def_pth
-  when: nova_virtual_env is undefined
-
-- name: Get nova venv path when nova_virtual_env is passed
-  shell: echo {{ nova_virtual_env }}
-  register: pre_usr_pth
-  when: nova_virtual_env is defined
-
 - name: Check stat default nova virt path
   stat:
     path: "{{ sys_nova_pth }}"
@@ -25,16 +15,16 @@
   when: nova_virtual_env is defined
 
 - set_fact: 
-    virtual_env_path: "{{ pre_def_pth.stdout }}"
-  when:
-    - chk_def_pth.stat.exists == true
-    - nova_virtual_env is undefined
+    virtual_env_path: "{{ sys_nova_pth }}"
+  when: >
+        ( nova_virtual_env is undefined ) and
+        ( chk_def_pth.stat.exists == true )
 
 - set_fact: 
-    virtual_env_path: "{{ pre_usr_pth.stdout }}"
-  when:
-    - chk_usr_pth.stat.exists == true
-    - nova_virtual_env is defined
+    virtual_env_path: "{{ nova_virtual_env }}"
+  when: > 
+        ( nova_virtual_env is defined ) and
+        ( chk_usr_pth.stat.exists == true )
 
 - set_fact:
     virtual_env: ". {{virtual_env_path}}/bin/activate"

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
@@ -1,22 +1,40 @@
 
+- set_fact:
+    sys_nova_pth: /openstack/venvs/nova-{{ venv_tag }}
+
 - name: Get nova venv path
-  shell: echo /openstack/venvs/nova-{{ venv_tag }}
-  register: pre_check_nova
+  shell: echo {{ sys_nova_pth }}
+  register: pre_def_pth
   when: nova_virtual_env is undefined
 
 - name: Get nova venv path when nova_virtual_env is passed
   shell: echo {{ nova_virtual_env }}
-  register: pre_check_nova
+  register: pre_usr_pth
   when: nova_virtual_env is defined
 
-- name: Get stats nova virtual path
+- name: Check stat default nova virt path
   stat:
-    path: "{{ pre_check_nova.stdout }}"
-  register: check_venv_path
+    path: "{{ sys_nova_pth }}"
+  register: chk_def_pth
+  when: nova_virtual_env is undefined
    
-- set_fact: virtual_env_path={{pre_check_nova.stdout}}
+- name: Check stat user provided nova virt path
+  stat:
+    path: "{{ nova_virtual_env }}"
+  register: chk_usr_pth
+  when: nova_virtual_env is defined
+
+- set_fact: 
+    virtual_env_path: "{{ pre_def_pth.stdout }}"
   when:
-    - check_venv_path.stat.exists == True 
+    - chk_def_pth.stat.exists == true
+    - nova_virtual_env is undefined
+
+- set_fact: 
+    virtual_env_path: "{{ pre_usr_pth.stdout }}"
+  when:
+    - chk_usr_pth.stat.exists == true
+    - nova_virtual_env is defined
 
 - set_fact:
     virtual_env: ". {{virtual_env_path}}/bin/activate"

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
@@ -14,6 +14,20 @@
   register: chk_usr_pth
   when: nova_virtual_env is defined
 
+- name: Failed when nova virt env not found
+  fail: 
+    msg: "Anisble Failed Cause Path {{ sys_nova_pth }} Not Found"
+  when: >
+        ( nova_virtual_env is undefined ) and
+        ( chk_def_pth.stat.exists == false )
+
+- name: Failed when nova virt env not found
+  fail: 
+    msg: "Anisble Failed Cause Path {{ nova_virtual_env }} Not Found"
+  when: > 
+        ( nova_virtual_env is defined ) and
+        ( chk_usr_pth.stat.exists == false )
+
 - set_fact: 
     virtual_env_path: "{{ sys_nova_pth }}"
   when: >

--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nova_compute_filter_file.yml
@@ -1,6 +1,13 @@
+
 - name: Get nova venv path
+  shell: echo /openstack/venvs/nova-{{ venv_tag }}
+  register: venv_path
+  when: nova_virtual_env is undefined
+
+- name: Get nova venv path when nova_virtual_env is passed
   shell: echo {{ nova_virtual_env }}
   register: venv_path
+  when: nova_virtual_env is defined
 
 - set_fact: virtual_env_path={{venv_path.stdout}}
 


### PR DESCRIPTION
with venv_tag we are fetching the value that had set into the ansible_facts, it should be equivalent to the DISTRIB_RELEASE  of Openstack which resides under /etc/openstack-release