### PR TITLE
TVAULT-5505 OSA remove taskflow_max_age variable from triliovault-wlm.conf  templates

### DIFF
--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/defaults/main.yml
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/defaults/main.yml
@@ -198,14 +198,12 @@ NOVA_GID: 998
 barbican_encryption: "True"
 
 
+## TASKFLOW PARAM
+TASKFLOW_PATH: "/var/lib/workloadmgr/taskflow"
+TASKFLOW_CACHE: 1024
+
 ## Triliovault Debian Repo string
 TRILIOVAULT_DEB_REPO_STRING: "triliodata-dev-stable-5-0"
 
 ### Triliovault RHEL Repo string
 TRILIOVAULT_RPM_REPO_STRING: "triliodata-dev-stable-5-0"
-
-
-## TASKFLOW PARAM
-TASKFLOW_PATH: "/var/lib/workloadmgr/taskflow"
-TASKFLOW_CACHE: 1024
-TASKFLOW_AGE: 10

--- a/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-wlm.conf.j2
+++ b/ansible/roles/openstack-ansible-os_triliovault_wlm/templates/triliovault-wlm.conf.j2
@@ -58,10 +58,6 @@ taskflow_path = {{ TASKFLOW_PATH }}
 # max cache size to keep up-to entries in memory
 taskflow_max_cache_size = {{ TASKFLOW_CACHE }}
 
-# max age in days to retain taskflow data
-taskflow_max_age = {{ TASKFLOW_AGE }}
-
-##
 rabbit_virtual_host = {{wlm_oslomsg_rpc_vhost}}
 compute_driver = libvirt.LibvirtDriver
 


### PR DESCRIPTION
Removed the taskflow_max_age variable from the trilioault-wlm.conf file