### PR TITLE
INTEROP-805 Set default value of TVAULT_PACKAGE_VERSION for OSA

### DIFF
--- a/ansible/environments/group_vars/all/vars.yml
+++ b/ansible/environments/group_vars/all/vars.yml
@@ -5,8 +5,9 @@ IP_ADDRESS: sample_tvault_ip_address
 ##Time Zone
 TIME_ZONE: "Etc/UTC"
 
-#Update TVAULT package version here, we will install mentioned version plugins for Example# TVAULT_PACKAGE_VERSION: 3.3.36
-TVAULT_PACKAGE_VERSION: 4.1.4
+## Don't update or modify the value of TVAULT_PACKAGE_VERSION
+## The default value of is '4.2.64'
+TVAULT_PACKAGE_VERSION: 4.2.64
 
 # Update Openstack dist code name like ussuri etc.
 OPENSTACK_DIST: ussuri


### PR DESCRIPTION
No need to set the value of TVAULT_PACKAGE_VERSION, it's default value should be '4.2.64'

