### PR TITLE
Set nova:nova ownership to the mount dir under wlm & datamover container 

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault/tasks/config.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/config.yml
@@ -74,7 +74,7 @@
     - item.value.enabled | bool
   with_dict: "{{ triliovault_services }}"
 
-- name: Ensuring /var/trilio directory exist
+- name: Ensuring /Var/trilio directory exist
   become: true
   file:
     path: "{{ triliovault_parent_data_directory }}"
@@ -82,8 +82,12 @@
     owner: "{{ triliovault_datamover_user_id }}"
     group: "{{ triliovault_datamover_group_id }}"
     mode: "0755"
-  when:
-    - inventory_hostname in groups[triliovault_datamover_group]
+  when: >
+        ( inventory_hostname in groups[triliovault_datamover_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_api_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_workloads_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_scheduler_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_cron_group] )
 
 - name: Ensuring "{{ triliovault_parent_data_directory }}/triliovault-mounts"  directory exist
   become: true
@@ -93,8 +97,12 @@
     owner: "{{ triliovault_datamover_user_id }}"
     group: "{{ triliovault_datamover_group_id }}"
     mode: "0755"
-  when:
-    - inventory_hostname in groups[triliovault_datamover_group]
+  when: >
+        ( inventory_hostname in groups[triliovault_datamover_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_api_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_workloads_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_scheduler_group] ) or
+        ( inventory_hostname in groups[triliovault_wlm_cron_group] )
 
 - include_tasks: copy-certs.yml
   when:

--- a/kolla-ansible/ansible/roles/triliovault/tasks/config.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/config.yml
@@ -74,7 +74,7 @@
     - item.value.enabled | bool
   with_dict: "{{ triliovault_services }}"
 
-- name: Ensuring /Var/trilio directory exist
+- name: Ensuring /var/trilio directory exist
   become: true
   file:
     path: "{{ triliovault_parent_data_directory }}"


### PR DESCRIPTION
The change ensures the dirs `/var/trilio` and` /var/trilio/triliovault-mounts` is present and owner is `nova:nova`