### PR TITLE
TVAULT-5325 Install the pre-requisite lxc packages 

### DIFF
--- a/ansible/tvault_pre_install.yml
+++ b/ansible/tvault_pre_install.yml
@@ -1,0 +1,55 @@
+---
+
+- hosts: localhost
+  become: true
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  tasks:
+    - name: Add & enable epel repo
+      yum_repository:
+        name: epel
+        description: EPEL YUM REPO
+        baseurl: https://download.fedoraproject.org/pub/epel/8/$basearch/
+        async: true
+        enabled: yes
+      when: >
+            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
+            (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
+
+    - name: Install snapd package
+      dnf:
+        name: snapd
+        state: present
+      when: >
+            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
+            (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
+
+    - name: Enable service httpd snapd
+      service:
+        name: snapd
+        enabled: yes
+      when: >
+            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
+            (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
+
+    - name: Install RPM lxc packages
+      dnf:
+        name:
+          - "lxc"
+          - "python3-lxc"
+          - "lxc-templates"
+        state: present
+      when: >
+            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
+            (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
+
+    - name: Install Debian lxc packages
+      package:
+        update_cache: yes
+        name:
+          - "lxc"
+          - "python3-lxc"
+          - "lxc-templates"
+        state: present
+      when: >
+            (ansible_distribution_major_version>="20.04" and ansible_distribution=="Debian")

--- a/ansible/tvault_pre_install.yml
+++ b/ansible/tvault_pre_install.yml
@@ -8,20 +8,19 @@
     - name: Add & enable epel repo
       yum_repository:
         name: epel
-        description: EPEL YUM REPO
-        baseurl: https://download.fedoraproject.org/pub/epel/8/$basearch/
-        async: true
-        enabled: yes
+        description: EPEL YUM Repo
+        baseurl: https://download.fedoraproject.org/pub/epel/$releasever/Everything/$basearch/
       when: >
-            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
+            (ansible_distribution_major_version>="8" and ansible_distribution=="CentOS") or
             (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
 
     - name: Install snapd package
-      dnf:
+      package:
+        update_cache: yes
         name: snapd
         state: present
       when: >
-            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
+            (ansible_distribution_major_version>="8" and ansible_distribution=="CentOS") or
             (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
 
     - name: Enable service httpd snapd
@@ -29,21 +28,10 @@
         name: snapd
         enabled: yes
       when: >
-            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
+            (ansible_distribution_major_version>="8" and ansible_distribution=="CentOS") or
             (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
 
-    - name: Install RPM lxc packages
-      dnf:
-        name:
-          - "lxc"
-          - "python3-lxc"
-          - "lxc-templates"
-        state: present
-      when: >
-            (ansible_distribution_major_version>="7" and ansible_distribution=="CentOS") or
-            (ansible_distribution_major_version>="8" and ansible_distribution=="RedHat")
-
-    - name: Install Debian lxc packages
+    - name: Install lxc packages
       package:
         update_cache: yes
         name:
@@ -51,5 +39,3 @@
           - "python3-lxc"
           - "lxc-templates"
         state: present
-      when: >
-            (ansible_distribution_major_version>="20.04" and ansible_distribution=="Debian")


### PR DESCRIPTION
with this playbook, the user is able to install the lxc packages under OSA  centos and ubuntu setups.
Validated the deployment on the OSA Wallaby CentOS 8 Stream  & Ubuntu 20.04

OSA Wallaby CentOS 8 Stream deploy logs

`  },
    "msg": "",
    "rc": 0,
    "results": [
        "Installed: python3-lxc-3.0.4-2.el8.x86_64",
        "Installed: lxc-templates-3.0.4-2.el8.x86_64"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************************************************************
localhost                  : ok=4    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0



EXIT NOTICE [Playbook execution success] **************************************`

OSA Wallaby Ubuntu 20.04 

` "Preparing to unpack .../16-cloud-image-utils_0.31-7-gd99b2d76-0ubuntu1_all.deb ...", "Unpacking cloud-image-utils (0.31-7-gd99b2d76-0ubuntu1) ...", "Selecting previously unselected package debootstrap.", "Preparing to unpack .../17-debootstrap_1.0.118ubuntu1.8_all.deb ...", "Unpacking debootstrap (1.0.118ubuntu1.8) ...", "Setting up genisoimage (9:1.1.11-3.1ubuntu1) ...", "Setting up debootstrap (1.0.118ubuntu1.8) ...", "Setting up lxc (1:4.0.12-0ubuntu1~20.04.1) ...", "Setting up python3-lxc (1:3.0.4-1ubuntu6) ...", "Setting up lxc-templates (3.0.4-3ubuntu1) ...", "Setting up libboost-iostreams1.71.0:amd64 (1.71.0-6ubuntu6) ...", "Setting up libnl-route-3-200:amd64 (3.4.0-1) ...", "Setting up libboost-thread1.71.0:amd64 (1.71.0-6ubuntu6) ...", "Setting up sharutils (1:4.15.2-4build1) ...", "Setting up libibverbs1:amd64 (28.0-1ubuntu1) ...", "Setting up ibverbs-providers:amd64 (28.0-1ubuntu1) ...", "Setting up librdmacm1:amd64 (28.0-1ubuntu1) ...", "Setting up librados2 (15.2.17-0ubuntu0.20.04.1) ...", "Setting up librbd1 (15.2.17-0ubuntu0.20.04.1) ...", "Setting up libiscsi7:amd64 (1.18.0-2) ...", "Setting up qemu-block-extra:amd64 (1:4.2-3ubuntu6.24) ...", "Setting up qemu-utils (1:4.2-3ubuntu6.24) ...", "Setting up cloud-image-utils (0.31-7-gd99b2d76-0ubuntu1) ...", "Processing triggers for install-info (6.7.0.dfsg.2-5) ...", "Processing triggers for libc-bin (2.31-0ubuntu9.9) ...", "Processing triggers for man-db (2.9.1-1) ..."]}

PLAY RECAP **********************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0


EXIT NOTICE [Playbook execution success] **************************************
===============================================================================
root@ansible:~#`





 