### PR TITLE
TVAULT-5546 snapshot and restore failing intermittently because of nfsvers=3

### DIFF
--- a/ansible/roles/ansible-tvault-contego-extension/tasks/nfs.yml
+++ b/ansible/roles/ansible-tvault-contego-extension/tasks/nfs.yml
@@ -18,7 +18,7 @@
   when: NFS_OPTS != ""
 
 - set_fact:
-      NFS_OPTIONS: "nolock,soft,timeo=180,intr,lookupcache=none"
+      NFS_OPTIONS: "nolock,soft,timeo=180,intr,lookupcache=none,nfsvers=3"
   when: NFS_OPTS == ""
 
 - debug: msg="value of NFS_OPTIONS is:{{NFS_OPTIONS}}" verbosity={{ verbosity_level }}


### PR DESCRIPTION
By default on compute node, it is taking NFS version 4 which we do not support 
we need to set nfsvers=3  like 'nolock,soft,timeo=180,intr,lookupcache=none,nfsvers=3'****