### PR TITLE
INTEROP-806 Incorporate the repo changes in DevOps code of Kolla-Ansible

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
+++ b/kolla-ansible/ansible/roles/triliovault/defaults/main.yml
@@ -140,9 +140,7 @@ triliovault_datamover_dimensions: "{{ default_container_dimensions }}"
 
 
 ###### START OF WORKLOADMGR ####
-triliovault_wlm_image: "{{ triliovault_docker_registry }}/trilio/{{ kolla_base_distro }}-binary-trilio-wlm"
-triliovault_wlm_tag: "{{ triliovault_tag }}"
-triliovault_wlm_image_full: "{{ triliovault_wlm_image }}:{{ triliovault_wlm_tag }}"
+triliovault_wlm_image_full: "{{ triliovault_docker_registry }}/trilio/kolla-{{ kolla_base_distro }}-trilio-wlm:{{ triliovault_tag }}"
 
 
 triliovault_wlm_api_dimensions: "{{ default_container_dimensions }}"


### PR DESCRIPTION
updated trilio-wlm container image
`---> OLD
triliovault_wlm_image: "{{ triliovault_docker_registry }}/trilio/{{ kolla_base_distro }}-binary-trilio-wlm:{{ triliovault_wlm_tag }}"
e.g.
docker.io/trilio/centos-binary-trilio-wlm:5.0.SB-wallaby

---> NEW
triliovault_wlm_image: "{{ triliovault_docker_registry }}/trilio/kolla-{{ kolla_base_distro }}-trilio-wlm:{{ triliovault_wlm_tag }}"
e.g.
docker.io/trilio/kolla-centos-trilio-wlm:5.0.SB-wallaby`