### PR TITLE
TVAULT-5783: Added code to skip TrilioVaultWLM service deletion by overcloud deploy command

### DIFF
--- a/redhat-director-scripts/rhosp16.2/services/trilio-datamover-api.yaml
+++ b/redhat-director-scripts/rhosp16.2/services/trilio-datamover-api.yaml
@@ -131,7 +131,9 @@ outputs:
             dmapi:
               password: {get_param: TrilioDatamoverPassword}
           region: {get_param: KeystoneRegion}
-          service: 'datamover'      
+          service: 'datamover'
+        TrilioVaultWLM:
+          service: 'workloads'
       config_settings:
         trilio::dmapi::dmapi_port: {get_param: DmApiPort}
         trilio::dmapi::dmapi_ssl_port: {get_param: DmApiSslPort}


### PR DESCRIPTION
-- Fixed for 4.2 hotfix.