### PR TITLE
Stable/4.3 Fixed directory name in hf_upgrade.sh

### DIFF
--- a/TVOAppliance/hf_upgrade.sh
+++ b/TVOAppliance/hf_upgrade.sh
@@ -3,7 +3,7 @@
 BASE_DIR="$(pwd)"
 PYTHON_VERSION="Python 3.8.12"
 OFFLINE_PKG_NAME="4.3-offlinePkgs.tar.gz"
-PKG_DIR_NAME="4.3.*offlinePkgs"
+PKG_DIR_NAME="4.3*offlinePkgs"
 BRANCH_NAME="trilio-4-3"
 UUID_NUM=`uuidgen`
 


### PR DESCRIPTION
Execution output given below:
```
[root@tvm2 4.3]# source hf_upgrade.sh -a
TVO Upgrade from current release to latest 4.3 release
Downloading  for 4.3 release
--2023-10-06 06:09:50--  http://0/
Resolving 0 (0)... 0.0.0.0
Connecting to 0 (0)|0.0.0.0|:80... connected.
HTTP request sent, awaiting response... 303 See Other
Location: https://0/ [following]
--2023-10-06 06:09:50--  https://0/
Connecting to 0 (0)|0.0.0.0|:443... connected.
ERROR: cannot verify 0's certificate, issued by ‘/C=US/ST=Massachusetts/L=Hopkinton/O=triliodata.com/OU=IT/CN=localhost/emailAddress=support@triliodata.com’:
  Self-signed certificate encountered.
    ERROR: certificate common name ‘localhost’ doesn't match requested host name ‘0’.
To connect to 0 insecurely, use `--no-check-certificate'.
--2023-10-06 06:09:51--  http://repos.trilio.io:8283/trilio-stable-4-3/offlinePkgs/4.3-offlinePkgs.tar.gz
Resolving repos.trilio.io (repos.trilio.io)... 149.56.2.142
Connecting to repos.trilio.io (repos.trilio.io)|149.56.2.142|:8283... connected.
HTTP request sent, awaiting response... 200 OK
Length: 214816049 (205M) [application/octet-stream]
Saving to: ‘4.3-offlinePkgs.tar.gz’

100%[==========================================================================================================>] 214,816,049 9.54MB/s   in 25s

2023-10-06 06:10:16 (8.04 MB/s) - ‘4.3-offlinePkgs.tar.gz’ saved [214816049/214816049]

FINISHED --2023-10-06 06:10:16--
Total wall clock time: 26s
Downloaded: 1 files, 205M in 25s (8.04 MB/s)
/opt/4.3/4.3-offlinePkgs.tar.gz present. we can continue with the installation.
Extracting /opt/4.3/4.3-offlinePkgs.tar.gz now
Installing /opt/4.3/4.3-offlinePkgs.tar.gz for 4.3 release
tar: Removing leading `/' from member names
/etc/tvault/
/etc/tvault/ssl/
/etc/tvault/ssl/localhost_bak.crt
/etc/tvault/ssl/localhost.crt
/etc/tvault/ssl/localhost.key
/etc/tvault/ssl/localhost_bak.key
/etc/tvault/ssl/gen-cer
/etc/tvault/ssl/localhost.pem
/etc/tvault/ssl/server.pem
/etc/tvault/ssl/server.crt
/etc/tvault/ssl/server.key
/etc/tvault/change_grafana_password.sh
/etc/tvault-config/
/etc/tvault-config/banner.yaml
/etc/tvault-config/tvault-config.conf
/etc/workloadmgr/
/etc/workloadmgr/workloadmgr.filters
/etc/workloadmgr/wlm-api.service
/etc/workloadmgr/wlm-cron.service
/etc/workloadmgr/wlm-scheduler.service
/etc/workloadmgr/wlm-workloads.service
/etc/workloadmgr/triliovault.pub
/etc/workloadmgr/tvault_key.pem
/etc/workloadmgr/workloadmgr.conf
/etc/workloadmgr/rootwrap.conf
/etc/workloadmgr/policy.json
/etc/workloadmgr/logging_sample.conf
/etc/workloadmgr/api-paste.ini
/etc/workloadmgr/rootwrap.d/
/etc/workloadmgr/rootwrap.d/workloadmgr.filters
/etc/workloadmgr/workloadmgr.conf.sample
/etc/workloadmgr/policy.yaml
Before installation disabling old and deleted MariaDB and Rabbitmq-server yum repositories
Loaded plugins: fastestmirror
Loaded plugins: fastestmirror
================================================================== repo: mariadb ===================================================================
[mariadb]
async = True
bandwidth = 0
base_persistdir = /var/lib/yum/repos/x86_64/7
baseurl = http://yum.mariadb.org/10.9/centos7-amd64
cache = 0
cachedir = /var/cache/yum/x86_64/7/mariadb
check_config_file_age = True
compare_providers_priority = 80
cost = 1000
deltarpm_metadata_percentage = 100
deltarpm_percentage =
enabled = False
enablegroups = True
exclude =
failovermethod = priority
ftp_disable_epsv = False
gpgcadir = /var/lib/yum/repos/x86_64/7/mariadb/gpgcadir
gpgcakey =
gpgcheck = True
gpgdir = /var/lib/yum/repos/x86_64/7/mariadb/gpgdir
gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
hdrdir = /var/cache/yum/x86_64/7/mariadb/headers
http_caching = all
includepkgs =
ip_resolve =
keepalive = True
keepcache = False
mddownloadpolicy = sqlite
mdpolicy = group:small
mediaid =
metadata_expire = 21600
metadata_expire_filter = read-only:present
metalink =
minrate = 0
mirrorlist =
mirrorlist_expire = 86400
name = MariaDB
old_base_cache_dir =
password =
persistdir = /var/lib/yum/repos/x86_64/7/mariadb
pkgdir = /var/cache/yum/x86_64/7/mariadb/packages
proxy = False
proxy_dict =
proxy_password =
proxy_username =
repo_gpgcheck = False
retries = 10
skip_if_unavailable = False
ssl_check_cert_permissions = True
sslcacert =
sslclientcert =
sslclientkey =
sslverify = True
throttle = 0
timeout = 30.0
ui_id = mariadb
ui_repoid_vars = releasever,
   basearch
username =

Python 3.8.12 package is already installed. We can skip Python package installation.
cp: overwrite ‘/home/stack/myansible/lib/python3.8/site-packages/tvault_configurator/conf/users.json’? active
Service {tvault-config} is in active state. Restarting {tvault-config} service
active
Service {wlm-api} is in active state. Restarting {wlm-api} service
active
Service {wlm-workloads} is in active state. Restarting {wlm-workloads} service
unknown
Service {wlm-cron} is in Inactive state. Cannot restart the service
unknown
Service {tvault-object-store} is in Inactive state. Cannot restart the service
active
Service {wlm-scheduler} is in active state. Restarting {wlm-scheduler} service
Performing DB upgrade steps
Database Already Exists
TVO appliance upgrade is complete. If TVO configuration is not done, please proceed with the same.
(myansible) [root@tvm2 4.3-offlinePkgs]# source ^C
(myansible) [root@tvm2 4.3-offlinePkgs]# service tvault-config status
Redirecting to /bin/systemctl status tvault-config.service
● tvault-config.service - Tvault config service
   Loaded: loaded (/etc/systemd/system/tvault-config.service; enabled; vendor preset: disabled)
   Active: active (running) since Fri 2023-10-06 06:10:43 UTC; 59s ago
 Main PID: 31434 (python3)
   CGroup: /system.slice/tvault-config.service
           └─31434 /home/stack/myansible/bin/python3 /home/stack/myansible/bin/tvault_config_bottle

Oct 06 06:10:43 tvm2 systemd[1]: Started Tvault config service.

```