### PR TITLE
TVAULT-6135: adding support to fail deployment when wlm cloud trust is not created

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/deploy.yml
+++ b/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/deploy.yml
@@ -24,4 +24,4 @@
 
 - include_tasks: wlm_cloud_trust.yml
   when: inventory_hostname in groups[triliovault_wlm_api_group]
-  run_once: True
+  tags: wlm_cloud_trust

--- a/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/wlm_cloud_trust.yml
+++ b/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/wlm_cloud_trust.yml
@@ -19,4 +19,5 @@
       - /etc/kolla/triliovault-wlm-api/api-paste.ini:/etc/triliovault-wlm/api-paste.ini:ro
       - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
       - /tmp/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
+  tags: wlm_cloud_trust
 

--- a/kolla-ansible/ansible/roles/triliovault/tasks/deploy.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/deploy.yml
@@ -24,4 +24,4 @@
 
 - include_tasks: wlm_cloud_trust.yml
   when: inventory_hostname in groups[triliovault_wlm_api_group]
-  run_once: True
+  tags: wlm_cloud_trust

--- a/kolla-ansible/ansible/roles/triliovault/tasks/wlm_cloud_trust.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/wlm_cloud_trust.yml
@@ -2,7 +2,6 @@
 
 - name: Create Cloud Admin Trust
   become: true
-  ignore_errors: yes
   docker_container:
     name: wlm_cloud_trust
     image: "{{ triliovault_wlm_image_full }}"
@@ -20,4 +19,5 @@
       - /etc/kolla/triliovault-wlm-api/api-paste.ini:/etc/triliovault-wlm/api-paste.ini:ro
       - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
       - /tmp/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
+  tags: wlm_cloud_trust
 

--- a/kolla-ansible/ansible/triliovault_site_2023.1.yml
+++ b/kolla-ansible/ansible/triliovault_site_2023.1.yml
@@ -37,3 +37,6 @@
     - { role: triliovault,
         tags: triliovault,
         when: enable_triliovault | bool }
+    - { role: triliovault,
+        tags: wlm_cloud_trust
+        }

--- a/kolla-ansible/ansible/triliovault_site_2023.2.yml
+++ b/kolla-ansible/ansible/triliovault_site_2023.2.yml
@@ -37,3 +37,6 @@
     - { role: triliovault,
         tags: triliovault,
         when: enable_triliovault | bool }
+    - { role: triliovault,
+        tags: wlm_cloud_trust
+        }

--- a/kolla-ansible/ansible/triliovault_site_2024.1.yml
+++ b/kolla-ansible/ansible/triliovault_site_2024.1.yml
@@ -37,3 +37,6 @@
     - { role: triliovault,
         tags: triliovault,
         when: enable_triliovault | bool }
+    - { role: triliovault,
+        tags: wlm_cloud_trust
+        }


### PR DESCRIPTION
Task to Check if Cloud Admin Trust creation was successful
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ab0e21ad-a7b0-44ad-9b6d-5ef1bb03e380" />
