### PR TITLE
TVAULT-6135 add wlm cloud trust tag to run separately

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/deploy.yml
+++ b/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/deploy.yml
@@ -21,7 +21,3 @@
 
 - include_tasks: start_wlm_cron_service.yml
   when: inventory_hostname in groups[triliovault_wlm_cron_group]
-
-- include_tasks: wlm_cloud_trust.yml
-  when: inventory_hostname in groups[triliovault_wlm_api_group]
-  run_once: True

--- a/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/get_cloud_details.yml
+++ b/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/get_cloud_details.yml
@@ -12,7 +12,7 @@
   when:
     - inventory_hostname in groups[triliovault_wlm_api_group]
   with_items:
-    - "/tmp/create_cloud_trust.sh"
+    - "/etc/kolla/triliovault-wlm-api/create_cloud_trust.sh"
 
 
 - name: Copy Triliovault-cloudrc to localhost

--- a/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/wlm_cloud_trust.yml
+++ b/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/wlm_cloud_trust.yml
@@ -25,3 +25,4 @@
           - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
           - /etc/kolla/triliovault-wlm-api/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
       tags: wlm_cloud_trust
+      run_once: true

--- a/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/wlm_cloud_trust.yml
+++ b/kolla-ansible/ansible/roles/triliovault-bobcat/tasks/wlm_cloud_trust.yml
@@ -1,22 +1,27 @@
 ---
 
 - name: Create Cloud Admin Trust
+  hosts: triliovault-wlm-api
   become: true
-  docker_container:
-    name: wlm_cloud_trust
-    image: "{{ triliovault_wlm_image_full }}"
-    command: 
-      - /bin/bash
-      - -c
-      - /opt/create_cloud_trust.sh
-    state: started
-    detach: no
-    interactive: yes
-    network_mode: host
-    tty: yes
-    volumes:
-      - /etc/kolla/triliovault-wlm-api/triliovault-wlm-api.conf:/etc/triliovault-wlm/triliovault-wlm.conf:ro
-      - /etc/kolla/triliovault-wlm-api/api-paste.ini:/etc/triliovault-wlm/api-paste.ini:ro
-      - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
-      - /tmp/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
-
+  gather_facts: false
+  tasks:
+    - name: Create Cloud Admin Trust
+      become: true
+      docker_container:
+        name: wlm_cloud_trust
+        image: "{{ triliovault_docker_registry }}/trilio/kolla-{{ kolla_base_distro }}-trilio-wlm:{{ triliovault_tag }}"
+        command: 
+          - /bin/bash
+          - -c
+          - /opt/create_cloud_trust.sh
+        state: started
+        detach: no
+        interactive: yes
+        network_mode: host
+        tty: yes
+        volumes:
+          - /etc/kolla/triliovault-wlm-api/triliovault-wlm-api.conf:/etc/triliovault-wlm/triliovault-wlm.conf:ro
+          - /etc/kolla/triliovault-wlm-api/api-paste.ini:/etc/triliovault-wlm/api-paste.ini:ro
+          - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
+          - /etc/kolla/triliovault-wlm-api/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
+      tags: wlm_cloud_trust

--- a/kolla-ansible/ansible/roles/triliovault/tasks/deploy.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/deploy.yml
@@ -21,7 +21,3 @@
 
 - include_tasks: start_wlm_cron_service.yml
   when: inventory_hostname in groups[triliovault_wlm_cron_group]
-
-- include_tasks: wlm_cloud_trust.yml
-  when: inventory_hostname in groups[triliovault_wlm_api_group]
-  run_once: True

--- a/kolla-ansible/ansible/roles/triliovault/tasks/get_cloud_details.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/get_cloud_details.yml
@@ -12,7 +12,7 @@
   when:
     - inventory_hostname in groups[triliovault_wlm_api_group]
   with_items:
-    - "/tmp/create_cloud_trust.sh"
+    - "/etc/kolla/triliovault-wlm-api/create_cloud_trust.sh"
 
 
 - name: Copy Triliovault-cloudrc to localhost

--- a/kolla-ansible/ansible/roles/triliovault/tasks/wlm_cloud_trust.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/wlm_cloud_trust.yml
@@ -25,3 +25,4 @@
           - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
           - /etc/kolla/triliovault-wlm-api/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
       tags: wlm_cloud_trust
+      run_once: true

--- a/kolla-ansible/ansible/roles/triliovault/tasks/wlm_cloud_trust.yml
+++ b/kolla-ansible/ansible/roles/triliovault/tasks/wlm_cloud_trust.yml
@@ -1,23 +1,27 @@
 ---
 
 - name: Create Cloud Admin Trust
+  hosts: triliovault-wlm-api
   become: true
-  ignore_errors: yes
-  docker_container:
-    name: wlm_cloud_trust
-    image: "{{ triliovault_wlm_image_full }}"
-    command: 
-      - /bin/bash
-      - -c
-      - /opt/create_cloud_trust.sh
-    state: started
-    detach: no
-    interactive: yes
-    network_mode: host
-    tty: yes
-    volumes:
-      - /etc/kolla/triliovault-wlm-api/triliovault-wlm-api.conf:/etc/triliovault-wlm/triliovault-wlm.conf:ro
-      - /etc/kolla/triliovault-wlm-api/api-paste.ini:/etc/triliovault-wlm/api-paste.ini:ro
-      - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
-      - /tmp/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
-
+  gather_facts: false
+  tasks:
+    - name: Create Cloud Admin Trust
+      become: true
+      docker_container:
+        name: wlm_cloud_trust
+        image: "{{ triliovault_docker_registry }}/trilio/kolla-{{ kolla_base_distro }}-trilio-wlm:{{ triliovault_tag }}"
+        command: 
+          - /bin/bash
+          - -c
+          - /opt/create_cloud_trust.sh
+        state: started
+        detach: no
+        interactive: yes
+        network_mode: host
+        tty: yes
+        volumes:
+          - /etc/kolla/triliovault-wlm-api/triliovault-wlm-api.conf:/etc/triliovault-wlm/triliovault-wlm.conf:ro
+          - /etc/kolla/triliovault-wlm-api/api-paste.ini:/etc/triliovault-wlm/api-paste.ini:ro
+          - /etc/kolla/triliovault-cloudrc:/opt/triliovault-cloudrc:rw
+          - /etc/kolla/triliovault-wlm-api/create_cloud_trust.sh:/opt/create_cloud_trust.sh:rw
+      tags: wlm_cloud_trust


### PR DESCRIPTION
To create WLM cloud trust, run
`ansible-playbook -i ./all-in-one /usr/local/share/kolla-ansible/ansible/roles/triliovault/tasks/wlm_cloud_trust.yml -e "@/etc/kolla/globals.yml"`