### PR TITLE
TVAULT-6883: Update datamover init scripts to create nova-compute rel…

### DIFF
--- a/openstack-helm/trilio-openstack/templates/bin/_triliovault-datamover-init.sh.tpl
+++ b/openstack-helm/trilio-openstack/templates/bin/_triliovault-datamover-init.sh.tpl
@@ -31,58 +31,6 @@ vault_storage_nfs_export = $NFS_SHARE
 EOF
 
 fi
-
 {{- end }}
 
-# --------------------------------------------
-# 1 & 2. Setup nova-libvirt.conf and nova-hypervisor.conf
-# Only if distro == mosk
-# --------------------------------------------
-{{- if eq (default "" .Values.distro) "mosk" }}
-
-# Set default values
-migration_interface="{{ default "mcc-lcm" .Values.conf.datamover.libvirt.live_migration_interface }}"
-listen_tls="{{ default "false" .Values.conf.datamover.libvirt.listen_tls }}"
-hypervisor_interface="{{ default "mcc-lcm" .Values.conf.datamover.libvirt.hypervisor_host_interface }}"
-
-touch /etc/nova/nova.conf.d/nova-libvirt.conf
-if [[ -n "$migration_interface" ]]; then
-    migration_address=$(ip a s $migration_interface | grep 'inet ' | awk '{print $2}' | awk -F "/" '{print $1}')
-fi
-
-qemu_connection_type="qemu+tcp"
-if [[ "$listen_tls" == "true" ]]; then
-    qemu_connection_type="qemu+tls"
-fi
-
-if [[ -n "$migration_address" ]]; then
-    cat <<EOF > /etc/nova/nova.conf.d/nova-libvirt.conf
-[libvirt]
-live_migration_inbound_addr = $migration_address
-connection_uri = "${qemu_connection_type}://${migration_address}/system"
-EOF
-    chgrp nova /etc/nova/nova.conf.d/nova-libvirt.conf
-else
-    echo "Migration address is not set."
-    exit 1
-fi
-
-# Prepare nova-hypervisor.conf
-if [[ -z "$hypervisor_interface" ]]; then
-    hypervisor_interface=$(ip -4 route list 0/0 | awk -F 'dev' '{ print $2; exit }' | awk '{ print $1 }') || exit 1
-fi
-
-hypervisor_address=$(ip a s "$hypervisor_interface" | grep 'inet ' | awk '{print $2}' | awk -F "/" '{print $1}')
-if [ -z "$hypervisor_address" ]; then
-    echo "Var my_ip is empty"
-    exit 1
-fi
-
-tee > /etc/nova/nova.conf.d/nova-hypervisor.conf << EOF
-[DEFAULT]
-my_ip = $hypervisor_address
-EOF
-
-chgrp nova /etc/nova/nova.conf.d/nova-hypervisor.conf
-
-{{- end }}
+<INJECT_INIT_FILES>

--- a/openstack-helm/trilio-openstack/templates/bin/_triliovault-datamover.sh.tpl
+++ b/openstack-helm/trilio-openstack/templates/bin/_triliovault-datamover.sh.tpl
@@ -20,8 +20,6 @@ COMMAND="${@:-start}"
 
 function start () {
   {{- $backup_target_type := .Values.conf.triliovault.backup_target_type }}
-  {{- $distro := default "" .Values.distro }}
-
   {{- if eq $backup_target_type "s3" }}
   ## Start triliovault object store service
   /usr/bin/python3 /usr/bin/s3vaultfuse.py --config-file=/etc/triliovault-object-store/triliovault-object-store.conf &
@@ -33,18 +31,11 @@ function start () {
   fi
   {{- end }}
 
-  CMD="/usr/bin/python3 /usr/bin/tvault-contego \
-    --config-file=/etc/nova/nova.conf"
-
-  {{- if eq $distro "mosk" }}
-  CMD+=" --config-file=/etc/nova/nova.conf.d/nova-hypervisor.conf"
-  CMD+=" --config-file=/etc/nova/nova.conf.d/nova-libvirt.conf"
-  {{- end }}
-
+  CMD="/usr/bin/python3 /usr/bin/tvault-contego"
+  CMD+=" --config-file=/etc/nova/nova.conf"
   CMD+=" --config-file=/etc/triliovault-datamover/triliovault-datamover.conf"
-  CMD+=" --config-file=/tmp/pod-shared-triliovault-datamover/triliovault-datamover-dynamic-values.conf"
+  <INJECT_CONFIG_FILES>
 
-  echo "Running: $CMD"
   eval $CMD
   status=$?
   if [ $status -ne 0 ]; then

--- a/openstack-helm/trilio-openstack/utils/get_admin_creds.sh
+++ b/openstack-helm/trilio-openstack/utils/get_admin_creds.sh
@@ -30,7 +30,9 @@ MYSQL_DBADMIN_PASSWORD=$(kubectl -n openstack get secrets/mariadb-dbadmin-passwo
 TRILIO_RABBITMQ_ADMIN_PASSWORD=$(kubectl -n trilio-openstack get secret/rabbitmq-default-user --template={{.data.password}} | base64 -d)
 TRILIO_RABBITMQ_ADMIN_USERNAME=$(kubectl -n trilio-openstack get secret/rabbitmq-default-user --template={{.data.username}} | base64 -d)
 
+## Create nova compute related conf file
 kubectl -n openstack get secret/nova-etc -o "jsonpath={.data['nova-compute\.conf']}" | base64 -d > ../templates/bin/_triliovault-nova-compute.conf.tpl
+./sync_nova_compute.sh
 
 CRT=$(kubectl -n openstack get secrets/keystone-tls-public -o "jsonpath={.data['tls\.crt']}" | base64 -d | sed 's/^[ \t]*//' | sed 's/^/            /')
 KEY=$(kubectl -n openstack get secrets/keystone-tls-public -o "jsonpath={.data['tls\.key']}" | base64 -d | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')

--- a/openstack-helm/trilio-openstack/utils/get_admin_creds_mosk.sh
+++ b/openstack-helm/trilio-openstack/utils/get_admin_creds_mosk.sh
@@ -30,7 +30,9 @@ MYSQL_DBADMIN_PASSWORD=$(kubectl -n openstack get secrets/mariadb-dbadmin-passwo
 TRILIO_RABBITMQ_ADMIN_PASSWORD=$(kubectl -n trilio-openstack get secret/rabbitmq-default-user --template={{.data.password}} | base64 -d)
 TRILIO_RABBITMQ_ADMIN_USERNAME=$(kubectl -n trilio-openstack get secret/rabbitmq-default-user --template={{.data.username}} | base64 -d)
 
+## Create nova compute related conf file
 kubectl -n openstack get secret/nova-etc -o "jsonpath={.data['nova-compute\.conf']}" | base64 -d > ../templates/bin/_triliovault-nova-compute.conf.tpl
+./sync_nova_compute.sh
 
 CRT=$(kubectl -n openstack get secrets/keystone-tls-public -o "jsonpath={.data['tls\.crt']}" | base64 -d | sed 's/^[ \t]*//' | sed 's/^/            /')
 KEY=$(kubectl -n openstack get secrets/keystone-tls-public -o "jsonpath={.data['tls\.key']}" | base64 -d | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')

--- a/openstack-helm/trilio-openstack/utils/get_admin_creds_vexxhost.sh
+++ b/openstack-helm/trilio-openstack/utils/get_admin_creds_vexxhost.sh
@@ -30,7 +30,9 @@ MYSQL_DBADMIN_PASSWORD=$(kubectl -n openstack get secrets/internal-percona-xtrad
 TRILIO_RABBITMQ_ADMIN_PASSWORD=$(kubectl -n trilio-openstack get secret/rabbitmq-default-user --template={{.data.password}} | base64 -d)
 TRILIO_RABBITMQ_ADMIN_USERNAME=$(kubectl -n trilio-openstack get secret/rabbitmq-default-user --template={{.data.username}} | base64 -d)
 
+## Create nova compute related conf file
 kubectl -n openstack get secret/nova-etc -o "jsonpath={.data['nova-compute\.conf']}" | base64 -d > ../templates/bin/_triliovault-nova-compute.conf.tpl
+./sync_nova_compute.sh
 
 CRT=$(kubectl -n cert-manager get secrets/cert-manager-selfsigned-ca -o "jsonpath={.data['tls\.crt']}" | base64 -d | sed 's/^[ \t]*//' | sed 's/^/            /')
 KEY=$(kubectl -n cert-manager get secrets/cert-manager-selfsigned-ca -o "jsonpath={.data['tls\.key']}" | base64 -d | awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}')

--- a/openstack-helm/trilio-openstack/utils/sync_nova_compute.sh
+++ b/openstack-helm/trilio-openstack/utils/sync_nova_compute.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -euo pipefail
+
+# ==========================================
+# Sync nova-compute-init.sh into Trilio templates
+# Detect config files from init content
+# ==========================================
+
+NAMESPACE="openstack"
+NOVA_CM="nova-bin"
+DATAMOVER_MAIN="../templates/bin/_triliovault-datamover.sh.tpl"
+DATAMOVER_INIT="../templates/bin/_triliovault-datamover-init.sh.tpl"
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# ==========================================
+# Fetch nova-compute-init.sh
+# ==========================================
+echo "Fetching nova-compute-init.sh from ConfigMap $NOVA_CM..."
+nova_init=$(kubectl get cm -n "$NAMESPACE" "$NOVA_CM" -o jsonpath='{.data.nova-compute-init\.sh}' || true)
+if [[ -z "$nova_init" ]]; then
+  echo "ERROR: Could not fetch nova-compute-init.sh from ConfigMap $NOVA_CM."
+  exit 1
+fi
+
+# ==========================================
+# Inject nova-compute-init.sh content into init template
+# ==========================================
+echo "Injecting nova-compute-init.sh content into $DATAMOVER_INIT..."
+tmp_out=$(mktemp)
+trap 'rm -f "$tmp_out"' EXIT
+
+# Keep lines from 'migration_interface' onward only
+nova_init_clean=$(echo "$nova_init" | sed -n '/migration_interface/,$p')
+
+while IFS= read -r line; do
+  if [[ "$line" == *"<INJECT_INIT_FILES>"* ]]; then
+    indent_prefix="${line%%<INJECT_INIT_FILES>*}"
+    while IFS= read -r init_line; do
+      echo "${indent_prefix}${init_line}" >> "$tmp_out"
+    done < <(echo "$nova_init_clean")
+  else
+    echo "$line" >> "$tmp_out"
+  fi
+done < "$DATAMOVER_INIT"
+
+mv "$tmp_out" "$DATAMOVER_INIT"
+
+sed -i 's|/tmp/pod-shared/|/tmp/pod-shared-triliovault-datamover/|g' "$DATAMOVER_INIT"
+sed -i 's|${NOVA_USER_UID}|nova|g' "$DATAMOVER_INIT"
+
+echo "Updated $DATAMOVER_INIT"
+
+# ==========================================
+# Parse injected init file to detect config files
+# ==========================================
+echo "Parsing config files from $DATAMOVER_INIT..."
+declare -A seen
+config_lines=()
+
+while read -r line; do
+  if [[ "$line" =~ [\>\ ]([/a-zA-Z0-9._-]+\.conf) ]]; then
+    file_path="${BASH_REMATCH[1]}"
+    base_name="$(basename "$file_path")"
+    if [[ "$file_path" == ".Values.conf" ]]; then
+      continue
+    fi
+    if [[ -z "${seen[$file_path]:-}" ]]; then
+      seen[$file_path]=1
+      config_lines+=("CMD+=\" --config-file=${file_path}\"")
+    fi
+  fi
+done < "$DATAMOVER_INIT"
+
+if [[ ${#config_lines[@]} -eq 0 ]]; then
+  echo "No config files detected from init script."
+else
+  echo "Found config files:"
+  printf ' - %s\n' "${config_lines[@]}"
+fi
+
+# ==========================================
+# Inject config files into _triliovault-datamover.sh.tpl
+# ==========================================
+echo "Injecting config files into $DATAMOVER_MAIN..."
+tmp_out=$(mktemp)
+trap 'rm -f "$tmp_out"' EXIT
+
+while IFS= read -r line; do
+  if [[ "$line" == *"<INJECT_CONFIG_FILES>"* ]]; then
+    indent_prefix="${line%%<INJECT_CONFIG_FILES>*}"
+    for l in "${config_lines[@]}"; do
+      echo "${indent_prefix}${l}" >> "$tmp_out"
+    done
+  else
+    echo "$line" >> "$tmp_out"
+  fi
+done < "$DATAMOVER_MAIN"
+
+mv "$tmp_out" "$DATAMOVER_MAIN"
+echo "Updated $DATAMOVER_MAIN"

--- a/openstack-helm/trilio-openstack/utils/uninstall.sh
+++ b/openstack-helm/trilio-openstack/utils/uninstall.sh
@@ -15,7 +15,7 @@ kubectl delete job triliovault-wlm-rabbit-init -n trilio-openstack
 kubectl delete job triliovault-datamover-db-drop -n trilio-openstack
 kubectl delete job triliovault-wlm-db-drop -n trilio-openstack
 kubectl delete job triliovault-wlm-cloud-trust -n trilio-openstack
-
+kubectl delete rabbitmqcluster rabbitmq -n trilio-openstack
 
 sleep 50s
 

--- a/openstack-helm/trilio-openstack/values_overrides/mosk25.1.yaml
+++ b/openstack-helm/trilio-openstack/values_overrides/mosk25.1.yaml
@@ -1,5 +1,4 @@
 ---
-distro: mosk
 images:
   tags:
     bootstrap: docker.io/openstackhelm/heat:2024.1-ubuntu_jammy


### PR DESCRIPTION
TVAULT-6883: Update datamover init scripts to create and inject Nova config files

The `sync_nova_compute.sh` script now fetches required values from the `nova-bin `ConfigMap and updates the `triliovault-datamover-init.sh `to generate Nova-related configuration files (e.g., nova-hypervisor.conf, nova-libvirt.conf, nova-compute-fqdn.conf, etc.).
These generated config files are then automatically passed to the tvault-contego service using the `--config-file` pattern, ensuring no duplicates and avoiding injection of junk or placeholder files.
