### PR TITLE
TVAULT-6907 : Exclude python3-django from getting updated

### DIFF
--- a/docker/redhat-director-scripts/docker/trilio-horizon-plugin/Dockerfile_rhosp17.1
+++ b/docker/redhat-director-scripts/docker/trilio-horizon-plugin/Dockerfile_rhosp17.1
@@ -23,7 +23,7 @@ RUN dnf config-manager \
 
 ADD trilio.repo /etc/yum.repos.d/
 RUN dnf install --releasever 9.2 python3-tvault-horizon-plugin-el9 -y
-RUN dnf --releasever 9.2 -y update-minimal --security --sec-severity=Important --sec-severity=Critical
+RUN dnf --releasever 9.2 -y update-minimal --security --sec-severity=Important --sec-severity=Critical --exclude=python3-django
 RUN rm /etc/yum.repos.d/trilio.repo
 
 ##Copy necessary files


### PR DESCRIPTION
similar change done for RHOSO18 : https://github.com/trilioData/triliovault-cfg-scripts/pull/1047