### PR TITLE
TVAULT-7226: Add s3vaultfuse-global.conf support for trilio-dms on RHOSO18

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/config/samples/tvo_v1_tvocontrolplane.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/config/samples/tvo_v1_tvocontrolplane.yaml
@@ -311,6 +311,46 @@ spec:
             runAsUser: 42436
         pod:
           runAsUser: 42424
+  dms:
+    # s3vaultfuse-global.conf parameters
+    # These configure how DMS spawns s3vaultfuse processes on control plane nodes.
+    # The values below are defaults -- modify only the params you need to override.
+    s3vaultfuse:
+      default:
+        vault_storage_type: "s3"
+        vault_s3_max_pool_connections: 50
+        vault_s3_read_timeout: 30
+        vault_s3_max_attempts: 3
+        vault_s3_auth_version: "DEFAULT"
+        vault_s3_signature_version: "default"
+        # SSL settings -- DMS overrides these via env vars; set here only to change the site-wide default
+        vault_s3_ssl: "True"
+        vault_s3_ssl_verify: "True"
+        vault_s3_region_name: "us-east-1"
+        # FUSE / caching
+        vault_segment_size: 33554432
+        vault_cache_size: 16
+        queue_depth: 100
+        worker_pool_size: 10
+        vault_retry_count: 2
+        # Thread pool
+        vault_enable_threadpool: "True"
+        vault_threaded_filesystem: "True"
+        max_uploads_pending: 20
+        # Logging
+        vault_logging_level: "error"
+        log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+        log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
+        trace_function_calls: "False"
+        # S3 bucket features
+        bucket_object_lock: "False"
+        use_manifest_suffix: "False"
+        azure_immutability_enabled: "False"
+        # Metadata cache
+        metadata_cache_max_items: 32
+        vault_cache_username: "nova"
+      s3fuse_sys_admin:
+        helper_command: "sudo /usr/bin/trilio-dms-rootwrap /etc/triliovault-dms/rootwrap.conf privsep-helper"
   rabbitmq:
     common:
       admin_password: EDIT_PASSWORD

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_s3vaultfuse_global_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_s3vaultfuse_global_conf.tpl
@@ -1,0 +1,47 @@
+[DEFAULT]
+# Storage type (default: s3)
+vault_storage_type = {{ .Values.dms.s3vaultfuse.default.vault_storage_type }}
+
+# S3 connection tuning
+vault_s3_max_pool_connections = {{ .Values.dms.s3vaultfuse.default.vault_s3_max_pool_connections }}
+vault_s3_read_timeout = {{ .Values.dms.s3vaultfuse.default.vault_s3_read_timeout }}
+vault_s3_max_attempts = {{ .Values.dms.s3vaultfuse.default.vault_s3_max_attempts }}
+vault_s3_auth_version = {{ .Values.dms.s3vaultfuse.default.vault_s3_auth_version }}
+vault_s3_signature_version = {{ .Values.dms.s3vaultfuse.default.vault_s3_signature_version }}
+
+# SSL settings (DMS overrides these via env vars by default)
+vault_s3_ssl = {{ .Values.dms.s3vaultfuse.default.vault_s3_ssl }}
+vault_s3_ssl_verify = {{ .Values.dms.s3vaultfuse.default.vault_s3_ssl_verify }}
+vault_s3_region_name = {{ .Values.dms.s3vaultfuse.default.vault_s3_region_name }}
+
+# FUSE / caching
+vault_segment_size = {{ .Values.dms.s3vaultfuse.default.vault_segment_size }}
+vault_cache_size = {{ .Values.dms.s3vaultfuse.default.vault_cache_size }}
+queue_depth = {{ .Values.dms.s3vaultfuse.default.queue_depth }}
+worker_pool_size = {{ .Values.dms.s3vaultfuse.default.worker_pool_size }}
+vault_retry_count = {{ .Values.dms.s3vaultfuse.default.vault_retry_count }}
+
+# Thread pool
+vault_enable_threadpool = {{ .Values.dms.s3vaultfuse.default.vault_enable_threadpool }}
+vault_threaded_filesystem = {{ .Values.dms.s3vaultfuse.default.vault_threaded_filesystem }}
+max_uploads_pending = {{ .Values.dms.s3vaultfuse.default.max_uploads_pending }}
+
+# Logging
+vault_logging_level = {{ .Values.dms.s3vaultfuse.default.vault_logging_level }}
+log_file = {{ .Values.dms.s3vaultfuse.default.log_file }}
+log_config_append = {{ .Values.dms.s3vaultfuse.default.log_config_append }}
+trace_function_calls = {{ .Values.dms.s3vaultfuse.default.trace_function_calls }}
+
+# S3 bucket features
+bucket_object_lock = {{ .Values.dms.s3vaultfuse.default.bucket_object_lock }}
+use_manifest_suffix = {{ .Values.dms.s3vaultfuse.default.use_manifest_suffix }}
+azure_immutability_enabled = {{ .Values.dms.s3vaultfuse.default.azure_immutability_enabled }}
+
+# Metadata cache
+metadata_cache_max_items = {{ .Values.dms.s3vaultfuse.default.metadata_cache_max_items }}
+
+# System user for cache directory ownership
+vault_cache_username = {{ .Values.dms.s3vaultfuse.default.vault_cache_username }}
+
+[s3fuse_sys_admin]
+helper_command = {{ .Values.dms.s3vaultfuse.s3fuse_sys_admin.helper_command }}

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/dms/daemonset-trilio-dms.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/dms/daemonset-trilio-dms.yaml
@@ -114,6 +114,10 @@ spec:
               mountPath: /etc/triliovault-dms/server.conf
               subPath: server.conf
               readOnly: true
+            - name: triliovault-dms-etc
+              mountPath: /etc/triliovault-dms/s3vaultfuse-global.conf
+              subPath: s3vaultfuse-global.conf
+              readOnly: true
             - name: triliovault-dms-bin
               mountPath: /tmp/triliovault-dms.sh
               subPath: triliovault-dms.sh

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/dms/secret-etc-dms.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/dms/secret-etc-dms.yaml
@@ -12,4 +12,6 @@ data:
     {{ tpl (.Files.Get "conf/_triliovault_dms_client_conf_wlm.tpl") . | b64enc }}
   client_dmapi.conf: |
     {{ tpl (.Files.Get "conf/_triliovault_dms_client_conf_dmapi.tpl") . | b64enc }}
+  s3vaultfuse-global.conf: |
+    {{ tpl (.Files.Get "conf/_s3vaultfuse_global_conf.tpl") . | b64enc }}
 {{- end }}

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
@@ -207,6 +207,37 @@ pod:
     triliovault_wlm_workloads: 3
     triliovault_wlm_cron: 1
     triliovault_wlm_scheduler: 3
+dms:
+  s3vaultfuse:
+    default:
+      vault_storage_type: "s3"
+      vault_s3_max_pool_connections: 50
+      vault_s3_read_timeout: 30
+      vault_s3_max_attempts: 3
+      vault_s3_auth_version: "DEFAULT"
+      vault_s3_signature_version: "default"
+      vault_s3_ssl: "True"
+      vault_s3_ssl_verify: "True"
+      vault_s3_region_name: "us-east-1"
+      vault_segment_size: 33554432
+      vault_cache_size: 16
+      queue_depth: 100
+      worker_pool_size: 10
+      vault_retry_count: 2
+      vault_enable_threadpool: "True"
+      vault_threaded_filesystem: "True"
+      max_uploads_pending: 20
+      vault_logging_level: "error"
+      log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+      log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
+      trace_function_calls: "False"
+      bucket_object_lock: "False"
+      use_manifest_suffix: "False"
+      azure_immutability_enabled: "False"
+      metadata_cache_max_items: 32
+      vault_cache_username: "nova"
+    s3fuse_sys_admin:
+      helper_command: "sudo /usr/bin/trilio-dms-rootwrap /etc/triliovault-dms/rootwrap.conf privsep-helper"
 workloadmgr:
   policyOverrides:
     # Example of overriding a default policy rule

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
@@ -300,6 +300,45 @@ spec:
       triliovault_wlm_workloads: 3
       triliovault_wlm_cron: 1
       triliovault_wlm_scheduler: 3
+  dms:
+    # s3vaultfuse-global.conf -- configures how DMS spawns s3vaultfuse processes.
+    # Parameters are written to /etc/triliovault-dms/s3vaultfuse-global.conf inside the DMS container.
+    s3vaultfuse:
+      default:
+        vault_storage_type: "s3"
+        vault_s3_max_pool_connections: 50
+        vault_s3_read_timeout: 30
+        vault_s3_max_attempts: 3
+        vault_s3_auth_version: "DEFAULT"
+        vault_s3_signature_version: "default"
+        # SSL settings -- DMS overrides these via env vars; set here only to change the site-wide default
+        vault_s3_ssl: "True"
+        vault_s3_ssl_verify: "True"
+        vault_s3_region_name: "us-east-1"
+        # FUSE / caching
+        vault_segment_size: 33554432
+        vault_cache_size: 16
+        queue_depth: 100
+        worker_pool_size: 10
+        vault_retry_count: 2
+        # Thread pool
+        vault_enable_threadpool: "True"
+        vault_threaded_filesystem: "True"
+        max_uploads_pending: 20
+        # Logging
+        vault_logging_level: "error"
+        log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+        log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
+        trace_function_calls: "False"
+        # S3 bucket features
+        bucket_object_lock: "False"
+        use_manifest_suffix: "False"
+        azure_immutability_enabled: "False"
+        # Metadata cache
+        metadata_cache_max_items: 32
+        vault_cache_username: "nova"
+      s3fuse_sys_admin:
+        helper_command: "sudo /usr/bin/trilio-dms-rootwrap /etc/triliovault-dms/rootwrap.conf privsep-helper"
   workloadmgr:
     policyOverrides:
       # Refer file policy-example.yaml for examples of overriding default policy rules. Uncomment and modify the below lines to override specific rules.

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
@@ -31,3 +31,36 @@ trilio_container_registry_username: ""
 trilio_container_registry_password: ""
 trilio_container_registry_url: "docker.io"
 
+# S3VaultFuse Global Config parameters
+# These can be overridden by adding s3vaultfuse_global to cm-trilio-datamover.yaml under trilio_env.yml
+s3vaultfuse_global:
+  default:
+    vault_storage_type: "s3"
+    vault_s3_max_pool_connections: 50
+    vault_s3_read_timeout: 30
+    vault_s3_max_attempts: 3
+    vault_s3_auth_version: "DEFAULT"
+    vault_s3_signature_version: "default"
+    vault_s3_ssl: "True"
+    vault_s3_ssl_verify: "True"
+    vault_s3_region_name: "us-east-1"
+    vault_segment_size: 33554432
+    vault_cache_size: 16
+    queue_depth: 100
+    worker_pool_size: 10
+    vault_retry_count: 2
+    vault_enable_threadpool: "True"
+    vault_threaded_filesystem: "True"
+    max_uploads_pending: 20
+    vault_logging_level: "error"
+    log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+    log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
+    trace_function_calls: "False"
+    bucket_object_lock: "False"
+    use_manifest_suffix: "False"
+    azure_immutability_enabled: "False"
+    metadata_cache_max_items: 32
+    vault_cache_username: "nova"
+  s3fuse_sys_admin:
+    helper_command: "sudo /usr/bin/trilio-dms-rootwrap /etc/triliovault-dms/rootwrap.conf privsep-helper"
+

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_dms.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_dms.yml
@@ -18,6 +18,17 @@
   notify:
     - Restart triliovault-dms
 
+- name: Create S3VaultFuse global configuration file
+  become: true
+  template:
+    src: s3vaultfuse_global_conf.j2
+    dest: "{{ triliovault_dms_config_dest }}/s3vaultfuse-global.conf"
+    owner: '42436'
+    group: '42436'
+    mode: '0644'
+  notify:
+    - Restart triliovault-dms
+
 - name: Create Triliovault DMS log directory
   become: true
   file:

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/s3vaultfuse_global_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/s3vaultfuse_global_conf.j2
@@ -1,0 +1,47 @@
+[DEFAULT]
+# Storage type (default: s3)
+vault_storage_type = {{ s3vaultfuse_global.default.vault_storage_type }}
+
+# S3 connection tuning
+vault_s3_max_pool_connections = {{ s3vaultfuse_global.default.vault_s3_max_pool_connections }}
+vault_s3_read_timeout = {{ s3vaultfuse_global.default.vault_s3_read_timeout }}
+vault_s3_max_attempts = {{ s3vaultfuse_global.default.vault_s3_max_attempts }}
+vault_s3_auth_version = {{ s3vaultfuse_global.default.vault_s3_auth_version }}
+vault_s3_signature_version = {{ s3vaultfuse_global.default.vault_s3_signature_version }}
+
+# SSL settings (DMS overrides these via env vars by default)
+vault_s3_ssl = {{ s3vaultfuse_global.default.vault_s3_ssl }}
+vault_s3_ssl_verify = {{ s3vaultfuse_global.default.vault_s3_ssl_verify }}
+vault_s3_region_name = {{ s3vaultfuse_global.default.vault_s3_region_name }}
+
+# FUSE / caching
+vault_segment_size = {{ s3vaultfuse_global.default.vault_segment_size }}
+vault_cache_size = {{ s3vaultfuse_global.default.vault_cache_size }}
+queue_depth = {{ s3vaultfuse_global.default.queue_depth }}
+worker_pool_size = {{ s3vaultfuse_global.default.worker_pool_size }}
+vault_retry_count = {{ s3vaultfuse_global.default.vault_retry_count }}
+
+# Thread pool
+vault_enable_threadpool = {{ s3vaultfuse_global.default.vault_enable_threadpool }}
+vault_threaded_filesystem = {{ s3vaultfuse_global.default.vault_threaded_filesystem }}
+max_uploads_pending = {{ s3vaultfuse_global.default.max_uploads_pending }}
+
+# Logging
+vault_logging_level = {{ s3vaultfuse_global.default.vault_logging_level }}
+log_file = {{ s3vaultfuse_global.default.log_file }}
+log_config_append = {{ s3vaultfuse_global.default.log_config_append }}
+trace_function_calls = {{ s3vaultfuse_global.default.trace_function_calls }}
+
+# S3 bucket features
+bucket_object_lock = {{ s3vaultfuse_global.default.bucket_object_lock }}
+use_manifest_suffix = {{ s3vaultfuse_global.default.use_manifest_suffix }}
+azure_immutability_enabled = {{ s3vaultfuse_global.default.azure_immutability_enabled }}
+
+# Metadata cache
+metadata_cache_max_items = {{ s3vaultfuse_global.default.metadata_cache_max_items }}
+
+# System user for cache directory ownership
+vault_cache_username = {{ s3vaultfuse_global.default.vault_cache_username }}
+
+[s3fuse_sys_admin]
+helper_command = {{ s3vaultfuse_global.s3fuse_sys_admin.helper_command }}

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/cm-trilio-datamover.yaml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/cm-trilio-datamover.yaml
@@ -23,3 +23,42 @@ data:
     trilio_container_registry_login_enabled: true
     trilio_container_registry_username: ""
     trilio_container_registry_url: "registry.connect.redhat.com"
+
+    # s3vaultfuse-global.conf parameters
+    # Modify the values below to override defaults for s3vaultfuse on compute nodes.
+    s3vaultfuse_global:
+      default:
+        vault_storage_type: "s3"
+        vault_s3_max_pool_connections: 50
+        vault_s3_read_timeout: 30
+        vault_s3_max_attempts: 3
+        vault_s3_auth_version: "DEFAULT"
+        vault_s3_signature_version: "default"
+        # SSL settings -- DMS overrides these via env vars; set here only to change the site-wide default
+        vault_s3_ssl: "True"
+        vault_s3_ssl_verify: "True"
+        vault_s3_region_name: "us-east-1"
+        # FUSE / caching
+        vault_segment_size: 33554432
+        vault_cache_size: 16
+        queue_depth: 100
+        worker_pool_size: 10
+        vault_retry_count: 2
+        # Thread pool
+        vault_enable_threadpool: "True"
+        vault_threaded_filesystem: "True"
+        max_uploads_pending: 20
+        # Logging
+        vault_logging_level: "error"
+        log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+        log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
+        trace_function_calls: "False"
+        # S3 bucket features
+        bucket_object_lock: "False"
+        use_manifest_suffix: "False"
+        azure_immutability_enabled: "False"
+        # Metadata cache
+        metadata_cache_max_items: 32
+        vault_cache_username: "nova"
+      s3fuse_sys_admin:
+        helper_command: "sudo /usr/bin/trilio-dms-rootwrap /etc/triliovault-dms/rootwrap.conf privsep-helper"


### PR DESCRIPTION
## Summary

Fixes **TVAULT-7226** — adds `s3vaultfuse-global.conf` configuration support for `trilio-dms` containers on both the control plane (Helm operator) and data plane (Ansible) sides in RHOSO18.

### Control Plane (Helm operator)
- New `conf/_s3vaultfuse_global_conf.tpl` — Helm template that renders `/etc/triliovault-dms/s3vaultfuse-global.conf`
- `secret-etc-dms.yaml` — `s3vaultfuse-global.conf` added as a Secret data key
- `daemonset-trilio-dms.yaml` — volumeMount added to inject the conf file into the DMS container
- `values.yaml` — new `dms.s3vaultfuse.default` and `dms.s3vaultfuse.s3fuse_sys_admin` sections with all configurable parameters and defaults
- `tvo-operator-inputs.yaml` and `config/samples/tvo_v1_tvocontrolplane.yaml` — updated with the new `dms.s3vaultfuse` section so users can override parameters

### Data Plane (Ansible)
- New `templates/s3vaultfuse_global_conf.j2` — Jinja2 template that renders `/etc/triliovault-dms/s3vaultfuse-global.conf` on compute nodes
- `defaults/main.yml` — `s3vaultfuse_global.default` and `s3vaultfuse_global.s3fuse_sys_admin` dicts with all parameters and defaults
- `tasks/configure_dms.yml` — new task to deploy the conf file
- `cm-trilio-datamover.yaml` — `s3vaultfuse_global` section added so users can override parameters by editing the ConfigMap

### Configuration structure
Both input files use lowercase YAML section keys (`default`, `s3fuse_sys_admin`) that map to the corresponding INI sections (`[DEFAULT]`, `[s3fuse_sys_admin]`) in the rendered conf file.

## Test plan
- [ ] Deploy RHOSO18 control plane — verify `/etc/triliovault-dms/s3vaultfuse-global.conf` is present in the DMS pod with correct values
- [ ] Deploy RHOSO18 data plane — verify `/etc/triliovault-dms/s3vaultfuse-global.conf` is present on compute nodes with correct values
- [ ] Override a parameter (e.g. `vault_s3_region_name`) in `tvo-operator-inputs.yaml` / `cm-trilio-datamover.yaml` and confirm the rendered file reflects the change
- [ ] Verify NFS and S3 backups succeed after deployment