### PR TITLE
TVAULT-7221: Fix triliovault-dms node_id to use canonical_hostname

### DIFF
--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_dms_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_dms_conf.j2
@@ -5,8 +5,10 @@ rabbitmq_url = rabbit://dmapi:{{ lookup('file', '/var/lib/openstack/configs/tril
 
 
 # Node identifier (optional, default: auto-detected hostname)
-# If not specified, DMS will use socket.gethostname()
-node_id = {{ ansible_fqdn }}
+# Must match OS-EXT-SRV-ATTR:host from 'openstack server show' (nova-compute host value).
+# canonical_hostname is set by the EDPM dataplane-operator from the ctlplane network FQDN,
+# which is the same variable the edpm_nova role uses for host= in nova.conf.
+node_id = {{ canonical_hostname }}
 
 # Keystone auth URL
 auth_url = {{ keystone_auth_url }}


### PR DESCRIPTION
## Summary

- Fixes NFS backups failing with "Unable to call vast_data_transfer" due to `node_id` mismatch in `triliovault-dms server.conf`
- Replaces `ansible_fqdn` with `canonical_hostname` for `node_id` in `triliovault_dms_conf.j2`

## Root Cause

`ansible_fqdn` resolves to the external FQDN (e.g. `edpm-compute-0.external...`) which does not match the `OS-EXT-SRV-ATTR:host` value that nova records for VMs. The DMS `node_id` must exactly match this value for backups to work.

## Fix

Use `{{ canonical_hostname }}` — the EDPM inventory variable derived from the **ctlplane network FQDN** by the dataplane-operator (`pkg/deployment/inventory.go`). This is the exact same variable the `edpm_nova` role writes to `host =` in `nova.conf`, ensuring DMS `node_id` always matches `OS-EXT-SRV-ATTR:host`.

**Reference**: `openstack-k8s-operators/edpm-ansible` — `roles/edpm_nova/templates/config/02-nova-host-specific.conf.j2`:
```
host = {{ canonical_hostname }}
```

## Test plan

- [ ] Deploy trilio-dms on RHOSO18 compute node
- [ ] Verify `node_id` in `/etc/triliovault-dms/server.conf` matches `openstack server show <vm> | grep OS-EXT-SRV-ATTR:host`
- [ ] Run a backup and confirm no "Unable to call vast_data_transfer" error