### PR TITLE
TVAULT-7238: Add rabbit_quorum_queue parameter in trilio-dms server.conf

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/config/samples/tvo_v1_tvocontrolplane.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/config/samples/tvo_v1_tvocontrolplane.yaml
@@ -339,7 +339,7 @@ spec:
         max_uploads_pending: 20
         # Logging
         vault_logging_level: "error"
-        log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+        log_file: "/var/log/triliovault/triliovault-object-store.log"
         log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
         trace_function_calls: "False"
         # S3 bucket features

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_dms_server_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_dms_server_conf.tpl
@@ -7,6 +7,9 @@
 # Keystone auth URL
 auth_url = {{ .Values.keystone.common.auth_url }}
 
+# Enable quorum queues for RabbitMQ (optional, default: True)
+rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+
 # Barbican SSL verification (optional, default: False)
 # Set to True to enable SSL certificate verification for Barbican API
 # Set to False to disable SSL verification (useful for self-signed certificates)

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_dms_server_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_dms_server_conf.tpl
@@ -7,8 +7,10 @@
 # Keystone auth URL
 auth_url = {{ .Values.keystone.common.auth_url }}
 
-# Enable quorum queues for RabbitMQ (optional, default: True)
-rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+{{- if .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+# Use quorum queue type for RabbitMQ
+rabbitmq_queue_type = quorum
+{{- end }}
 
 # Barbican SSL verification (optional, default: False)
 # Set to True to enable SSL certificate verification for Barbican API

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
@@ -99,6 +99,7 @@ rabbitmq:
   cluster:
     api_version: "rabbitmq.com/v1beta1"
     replicas: 3
+    rabbit_quorum_queue: true
     image: "rabbitmq:3.13.7-management"
     resources:
       requests:

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
@@ -99,7 +99,7 @@ rabbitmq:
   cluster:
     api_version: "rabbitmq.com/v1beta1"
     replicas: 3
-    rabbit_quorum_queue: true
+    rabbit_quorum_queue: false
     image: "rabbitmq:3.13.7-management"
     resources:
       requests:

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
@@ -229,7 +229,7 @@ dms:
       vault_threaded_filesystem: "True"
       max_uploads_pending: 20
       vault_logging_level: "error"
-      log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+      log_file: "/var/log/triliovault/triliovault-object-store.log"
       log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
       trace_function_calls: "False"
       bucket_object_lock: "False"

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
@@ -327,7 +327,7 @@ spec:
         max_uploads_pending: 20
         # Logging
         vault_logging_level: "error"
-        log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+        log_file: "/var/log/triliovault/triliovault-object-store.log"
         log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
         trace_function_calls: "False"
         # S3 bucket features

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
@@ -14,7 +14,7 @@ cinder_backend_ceph: true
 libvirt_images_rbd_ceph_conf: "/etc/ceph/ceph.conf"
 ceph_cinder_user: "cinder"
 oslomsg_rpc_use_ssl: true
-rabbit_quorum_queue: true
+rabbit_quorum_queue: false
 cinder_backend_power_flex: false
 ## Do we need this parameter? Check datamover conf.
 cinder_http_retries: "10"

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
@@ -54,7 +54,7 @@ s3vaultfuse_global:
     vault_threaded_filesystem: "True"
     max_uploads_pending: 20
     vault_logging_level: "error"
-    log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+    log_file: "/var/log/triliovault/triliovault-object-store.log"
     log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
     trace_function_calls: "False"
     bucket_object_lock: "False"

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
@@ -14,6 +14,7 @@ cinder_backend_ceph: true
 libvirt_images_rbd_ceph_conf: "/etc/ceph/ceph.conf"
 ceph_cinder_user: "cinder"
 oslomsg_rpc_use_ssl: true
+rabbit_quorum_queue: true
 cinder_backend_power_flex: false
 ## Do we need this parameter? Check datamover conf.
 cinder_http_retries: "10"

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_dms_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_dms_conf.j2
@@ -3,6 +3,9 @@
 # Supported schemes: amqp://, amqps://, rabbit://, rabbitmq://, rabbit+ssl://
 rabbitmq_url = rabbit://dmapi:{{ lookup('file', '/var/lib/openstack/configs/trilio-datamover/DmapiRabbitPassword') | trim }}@{{ rabbit_host }}:{{ rabbit_port }}/dmapi{% if rabbit_ssl %}?ssl=1{% endif %}
 
+# Enable quorum queues for RabbitMQ (optional, default: True)
+rabbit_quorum_queue = {{ rabbit_quorum_queue }}
+
 
 # Node identifier (optional, default: auto-detected hostname)
 # Must match OS-EXT-SRV-ATTR:host from 'openstack server show' (nova-compute host value).

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_dms_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_dms_conf.j2
@@ -3,8 +3,10 @@
 # Supported schemes: amqp://, amqps://, rabbit://, rabbitmq://, rabbit+ssl://
 rabbitmq_url = rabbit://dmapi:{{ lookup('file', '/var/lib/openstack/configs/trilio-datamover/DmapiRabbitPassword') | trim }}@{{ rabbit_host }}:{{ rabbit_port }}/dmapi{% if rabbit_ssl %}?ssl=1{% endif %}
 
-# Enable quorum queues for RabbitMQ (optional, default: True)
-rabbit_quorum_queue = {{ rabbit_quorum_queue }}
+{% if rabbit_quorum_queue %}
+# Use quorum queue type for RabbitMQ
+rabbitmq_queue_type = quorum
+{% endif %}
 
 
 # Node identifier (optional, default: auto-detected hostname)

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/cm-trilio-datamover.yaml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/cm-trilio-datamover.yaml
@@ -50,7 +50,7 @@ data:
         max_uploads_pending: 20
         # Logging
         vault_logging_level: "error"
-        log_file: "/var/log/tvault-object-store/tvault-object-store.log"
+        log_file: "/var/log/triliovault/triliovault-object-store.log"
         log_config_append: "/etc/triliovault-object-store/object_store_logging.conf"
         trace_function_calls: "False"
         # S3 bucket features


### PR DESCRIPTION
## Summary
- Add `rabbit_quorum_queue` parameter to control plane trilio-dms `server.conf` (Helm chart template `_triliovault_dms_server_conf.tpl`) using `{{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}`
- Add `rabbit_quorum_queue: true` to Helm chart `values.yaml` under `rabbitmq.cluster`
- Add `rabbit_quorum_queue` parameter to data plane trilio-dms `server.conf` (Ansible template `triliovault_dms_conf.j2`) using `{{ rabbit_quorum_queue }}`
- Add `rabbit_quorum_queue: true` default in data plane Ansible `defaults/main.yml`

## Test plan
- [ ] Deploy T4O on RHOSO18 control plane and verify `server.conf` contains `rabbit_quorum_queue = true`
- [ ] Deploy T4O on RHOSO18 data plane (EDPM node) and verify `server.conf` contains `rabbit_quorum_queue = true`
- [ ] Verify trilio-dms service starts successfully on both control plane and data plane

Jira: TVAULT-7238