### PR TITLE
fix(rhosp18): support both FR4 and FR5 nova config paths (TVAULT-7318)

### DIFF
--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_datamover.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_datamover.yml
@@ -82,6 +82,16 @@
 #    group: '42436'
 #    mode: '0755'
 
+- name: Check for FR5 nova config path
+  become: true
+  ansible.builtin.stat:
+    path: /var/lib/openstack/nova
+  register: nova_config_fr5
+
+- name: Set nova config directory based on RHOSO version
+  ansible.builtin.set_fact:
+    nova_config_dir: "{{ '/var/lib/openstack/nova' if nova_config_fr5.stat.exists else '/var/lib/openstack/config/nova' }}"
+
 - name: Render triliovault-datamover container
   become: true
   ansible.builtin.template:

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault-datamover-container-json.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault-datamover-container-json.j2
@@ -37,7 +37,7 @@
 {% if cinder_backend_power_flex|bool %}
         "/opt/emc/scaleio/openstack/connector.conf:/opt/emc/scaleio/openstack/connector.conf:ro",
 {% endif %}
-        "/var/lib/openstack/config/nova:/var/lib/kolla/config_files/nova:ro"
+        "{{ nova_config_dir }}:/var/lib/kolla/config_files/nova:ro"
     ]
 }
 


### PR DESCRIPTION
## Summary

- RHOSO FR5 changed the nova config directory path from `/var/lib/openstack/config/nova` (FR4) to `/var/lib/openstack/nova` (FR5).
- The datamover container's volume mount was hard-coded to the FR4 path, causing failures on FR5 nodes.
- This fix uses an Ansible `stat` task to detect which path exists at deploy time and sets `nova_config_dir` accordingly, so the correct path is mounted into the container.
- Mixed environments (some nodes on FR4, some on FR5) are handled transparently since detection runs per-host.

## Test plan

- [ ] Deploy on an FR4 environment (18.0.17 or earlier) — datamover container should mount `/var/lib/openstack/config/nova`
- [ ] Deploy on an FR5 environment (18.0.18+) — datamover container should mount `/var/lib/openstack/nova`
- [ ] Verify datamover service starts and functions correctly on both

Fixes: TVAULT-7318