### PR TITLE
TVAULT-7324: use kolla venv python3 for dmapi-dbsync to avoid oslo_db.concurr…

### DIFF
--- a/docker/kolla-ansible/trilio-datamover-api/triliovault_datamover_api_extend_start.sh
+++ b/docker/kolla-ansible/trilio-datamover-api/triliovault_datamover_api_extend_start.sh
@@ -6,11 +6,11 @@
 ## TODO: Uncomment following code once we get dmapi-dbsync tool
 
 if [[ "${!KOLLA_BOOTSTRAP[@]}" ]]; then
-    dmapi-dbsync
+    /var/lib/kolla/venv/bin/python3 /usr/bin/dmapi-dbsync
     exit 0
 fi
 
 if [[ "${!KOLLA_UPGRADE[@]}" ]]; then
-    dmapi-dbsync
+    /var/lib/kolla/venv/bin/python3 /usr/bin/dmapi-dbsync
     exit 0
 fi


### PR DESCRIPTION
…ency ImportError

On Ubuntu Epoxy (2025.1+), apt installs oslo.db 15.1.0+ which removed oslo_db.concurrency. The dmapi-dbsync script's system Python shebang picks up the system oslo.db. Using the kolla venv python3 ensures the downgraded oslo.db<15.1.0 is used for bootstrap and upgrade db sync.