### PR TITLE
TVAULT-7328: skip amqp_durable_queues when rabbit_quorum_queue is enabled

### DIFF
--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
@@ -20,7 +20,9 @@ keyring_ext = .keyring
 [oslo_messaging_rabbit]
 rabbit_quorum_queue = {{ rabbit_quorum_queue }}
 ssl = {{ rabbit_ssl }}
+{% if not rabbit_quorum_queue | bool %}
 amqp_durable_queues = false
+{% endif %}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [dmapi_database]


### PR DESCRIPTION
## Summary
- When `rabbit_quorum_queue = True`, the `amqp_durable_queues` parameter is now omitted from `triliovault_datamover_conf.j2`
- When `rabbit_quorum_queue = False`, `amqp_durable_queues = false` is included as before

## Problem
With quorum queues enabled, RabbitMQ manages exchange durability internally. Explicitly setting `amqp_durable_queues = false` caused a `PRECONDITION_FAILED (406)` error on the `contego_fanout` exchange in the `dmapi` vhost:
```
inequivalent arg 'durable' for exchange 'contego_fanout' in vhost 'dmapi': received 'true' but current is 'false'
```
This prevented the `triliovault_datamover` container from starting.

## Changes
- `redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2`: wrapped `amqp_durable_queues` in `{% if not rabbit_quorum_queue | bool %}` conditional

## Test plan
- [ ] Deploy datamover with `rabbit_quorum_queue: true` — confirm `amqp_durable_queues` absent from generated conf and container starts cleanly
- [ ] Deploy datamover with `rabbit_quorum_queue: false` — confirm `amqp_durable_queues = false` present in generated conf