### PR TITLE
TVAULT-7328: set amqp_durable_queues based on rabbit_quorum_queue in datamover and dmapi conf

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
@@ -35,6 +35,7 @@ auth_uri = {{ .Values.keystone.common.auth_uri }}
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+amqp_durable_queues = {{ if .Values.rabbitmq.cluster.rabbit_quorum_queue }}true{{ else }}false{{ end }}
 
 [oslo_messaging_notifications]
 driver = {{ .Values.rabbitmq.common.driver }}

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
@@ -112,4 +112,5 @@ helper_command = sudo /usr/bin/workloadmgr-rootwrap /etc/triliovault-wlm/rootwra
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+amqp_durable_queues = {{ if .Values.rabbitmq.cluster.rabbit_quorum_queue }}true{{ else }}false{{ end }}
 

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
@@ -20,9 +20,7 @@ keyring_ext = .keyring
 [oslo_messaging_rabbit]
 rabbit_quorum_queue = {{ rabbit_quorum_queue }}
 ssl = {{ rabbit_ssl }}
-{% if not rabbit_quorum_queue | bool %}
-amqp_durable_queues = false
-{% endif %}
+amqp_durable_queues = {{ 'true' if rabbit_quorum_queue | bool else 'false' }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [dmapi_database]


### PR DESCRIPTION
## Summary
- `amqp_durable_queues` is now set dynamically based on `rabbit_quorum_queue` in both `triliovault-datamover.conf` and `triliovault-datamover-api.conf`
- `rabbit_quorum_queue = true` → `amqp_durable_queues = true`
- `rabbit_quorum_queue = false` → `amqp_durable_queues = false`

## Problem
With quorum queues enabled, the `contego_fanout` exchange in the `dmapi` RabbitMQ vhost was being declared with mismatched durability properties, causing a `PRECONDITION_FAILED (406)` error and preventing the `triliovault_datamover` container from starting.

## Changes
- `redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2`: replaced conditional skip with explicit `true`/`false` value using Jinja2 ternary
- `redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl`: added `amqp_durable_queues` with Helm conditional

## Test plan
- [ ] Deploy with `rabbit_quorum_queue: true` — confirm `amqp_durable_queues = true` in both generated conf files and datamover container starts cleanly
- [ ] Deploy with `rabbit_quorum_queue: false` — confirm `amqp_durable_queues = false` in both generated conf files