### PR TITLE
TVAULT-7336: fix iSCSI portal login failure in kolla Epoxy datamover

### DIFF
--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
@@ -43,6 +43,10 @@ RUN dnf install -y --allowerasing \
     https://cbs.centos.org/kojifiles/packages/python-eventlet/0.30.2/1.el9s/noarch/python3-eventlet-0.30.2-1.el9s.noarch.rpm
 RUN dnf install -y python3-s3fuse-plugin-el9
 
+## Explicitly pin iscsi-initiator-utils to 6.2.1.9 (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
+RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" || \
+    dnf install -y --allowerasing "iscsi-initiator-utils-6.2.1.9*" "iscsi-initiator-utils-iscsiuio-6.2.1.9*"
+
 ## Copy locally built virt-v2v-in-place binary
 COPY virt-v2v-in-place /usr/local/bin/
 

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
@@ -20,8 +20,9 @@ RUN dnf config-manager --save --setopt=epel.skip_if_unavailable=true
 ADD trilio.repo /etc/yum.repos.d/
 
 ##Install Required Packages
+# Exclude iscsi-initiator-utils from update: 6.2.1.11 breaks iSCSI portal login; keep 6.2.1.9 from base image (TVAULT-7336)
 RUN set -ex \
-    && dnf update -y
+    && dnf update -y --exclude=iscsi-initiator-utils\*
 
 ##Add nova user into the disk and kvm group
 RUN usermod -u 42436 nova && groupmod -g 42436 nova && usermod -aG disk,libvirt,kolla,kvm nova

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
@@ -35,9 +35,9 @@ RUN mkdir -p /var/log/triliovault /var/trilio/triliovault-mounts /var/triliovaul
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 	
 ##Install datamover packages
-RUN dnf install openstack-nova-common python3-nova python3-novaclient python3-monotonic udev fuse -y \
-    && dnf install python3-tvault-contego-el9 qemu-img ceph-common python3-libvirt python3-cinderclient qemu-kvm-block-rbd -y \
-    && dnf install virt-v2v virtio-win nbdkit -y
+RUN dnf install openstack-nova-common python3-nova python3-novaclient python3-monotonic udev fuse -y --exclude=iscsi-initiator-utils\* \
+    && dnf install python3-tvault-contego-el9 qemu-img ceph-common python3-libvirt python3-cinderclient qemu-kvm-block-rbd -y --exclude=iscsi-initiator-utils\* \
+    && dnf install virt-v2v virtio-win nbdkit -y --exclude=iscsi-initiator-utils\*
 
 RUN dnf install -y --allowerasing \
     https://cbs.centos.org/kojifiles/packages/python-eventlet/0.30.2/1.el9s/noarch/python3-eventlet-0.30.2-1.el9s.noarch.rpm

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
@@ -43,10 +43,11 @@ RUN dnf install -y --allowerasing --exclude=iscsi-initiator-utils\* \
     https://cbs.centos.org/kojifiles/packages/python-eventlet/0.30.2/1.el9s/noarch/python3-eventlet-0.30.2-1.el9s.noarch.rpm
 RUN dnf install -y --exclude=iscsi-initiator-utils\* python3-s3fuse-plugin-el9
 
-## Verify iscsi-initiator-utils is 6.2.1.9 from the base image (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
-## Rocky repos no longer carry 6.2.1.9; we preserve it by excluding it from all dnf steps above.
-RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" \
-    || { rpm -q iscsi-initiator-utils; echo "FATAL: iscsi-initiator-utils is not 6.2.1.9"; exit 1; }
+## Explicitly install iscsi-initiator-utils 6.2.1.9 from Rocky 9.4 vault (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
+## Rocky current repos only carry 6.2.1.11; pin to 6.2.1.9 from the vault with --allowerasing to downgrade if needed.
+RUN dnf install -y --allowerasing \
+    https://dl.rockylinux.org/vault/rocky/9.4/BaseOS/x86_64/os/Packages/i/iscsi-initiator-utils-6.2.1.9-1.gita65a472.el9.x86_64.rpm \
+    https://dl.rockylinux.org/vault/rocky/9.4/BaseOS/x86_64/os/Packages/i/iscsi-initiator-utils-iscsiuio-6.2.1.9-1.gita65a472.el9.x86_64.rpm
 
 ## Copy locally built virt-v2v-in-place binary
 COPY virt-v2v-in-place /usr/local/bin/

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2024.1_rocky
@@ -39,13 +39,14 @@ RUN dnf install openstack-nova-common python3-nova python3-novaclient python3-mo
     && dnf install python3-tvault-contego-el9 qemu-img ceph-common python3-libvirt python3-cinderclient qemu-kvm-block-rbd -y --exclude=iscsi-initiator-utils\* \
     && dnf install virt-v2v virtio-win nbdkit -y --exclude=iscsi-initiator-utils\*
 
-RUN dnf install -y --allowerasing \
+RUN dnf install -y --allowerasing --exclude=iscsi-initiator-utils\* \
     https://cbs.centos.org/kojifiles/packages/python-eventlet/0.30.2/1.el9s/noarch/python3-eventlet-0.30.2-1.el9s.noarch.rpm
-RUN dnf install -y python3-s3fuse-plugin-el9
+RUN dnf install -y --exclude=iscsi-initiator-utils\* python3-s3fuse-plugin-el9
 
-## Explicitly pin iscsi-initiator-utils to 6.2.1.9 (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
-RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" || \
-    dnf install -y --allowerasing "iscsi-initiator-utils-6.2.1.9*" "iscsi-initiator-utils-iscsiuio-6.2.1.9*"
+## Verify iscsi-initiator-utils is 6.2.1.9 from the base image (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
+## Rocky repos no longer carry 6.2.1.9; we preserve it by excluding it from all dnf steps above.
+RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" \
+    || { rpm -q iscsi-initiator-utils; echo "FATAL: iscsi-initiator-utils is not 6.2.1.9"; exit 1; }
 
 ## Copy locally built virt-v2v-in-place binary
 COPY virt-v2v-in-place /usr/local/bin/

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
@@ -40,13 +40,14 @@ RUN dnf install openstack-nova-common python3-nova python3-novaclient python3-mo
     && dnf install virt-v2v virtio-win nbdkit -y --exclude=iscsi-initiator-utils\*
 
 ## Downgrade eventlet to 0.30.2-1 from CBS to satisfy s3fuse eventlet <= 0.30.2-4 constraint
-RUN dnf install -y --allowerasing \
+RUN dnf install -y --allowerasing --exclude=iscsi-initiator-utils\* \
     https://cbs.centos.org/kojifiles/packages/python-eventlet/0.30.2/1.el9s/noarch/python3-eventlet-0.30.2-1.el9s.noarch.rpm
-RUN dnf install -y python3-s3fuse-plugin-el9
+RUN dnf install -y --exclude=iscsi-initiator-utils\* python3-s3fuse-plugin-el9
 
-## Explicitly pin iscsi-initiator-utils to 6.2.1.9 (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
-RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" || \
-    dnf install -y --allowerasing "iscsi-initiator-utils-6.2.1.9*" "iscsi-initiator-utils-iscsiuio-6.2.1.9*"
+## Verify iscsi-initiator-utils is 6.2.1.9 from the base image (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
+## Rocky repos no longer carry 6.2.1.9; we preserve it by excluding it from all dnf steps above.
+RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" \
+    || { rpm -q iscsi-initiator-utils; echo "FATAL: iscsi-initiator-utils is not 6.2.1.9"; exit 1; }
 
 ## Copy locally built virt-v2v-in-place binary
 COPY virt-v2v-in-place /usr/local/bin/

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
@@ -35,9 +35,9 @@ RUN mkdir -p /var/log/triliovault /var/trilio/triliovault-mounts /var/triliovaul
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 	
 ##Install datamover packages
-RUN dnf install openstack-nova-common python3-nova python3-novaclient python3-monotonic udev fuse -y \
-    && dnf install python3-tvault-contego-el9 qemu-img ceph-common python3-libvirt python3-cinderclient qemu-kvm-block-rbd -y \
-    && dnf install virt-v2v virtio-win nbdkit -y
+RUN dnf install openstack-nova-common python3-nova python3-novaclient python3-monotonic udev fuse -y --exclude=iscsi-initiator-utils\* \
+    && dnf install python3-tvault-contego-el9 qemu-img ceph-common python3-libvirt python3-cinderclient qemu-kvm-block-rbd -y --exclude=iscsi-initiator-utils\* \
+    && dnf install virt-v2v virtio-win nbdkit -y --exclude=iscsi-initiator-utils\*
 
 ## Downgrade eventlet to 0.30.2-1 from CBS to satisfy s3fuse eventlet <= 0.30.2-4 constraint
 RUN dnf install -y --allowerasing \

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
@@ -44,6 +44,10 @@ RUN dnf install -y --allowerasing \
     https://cbs.centos.org/kojifiles/packages/python-eventlet/0.30.2/1.el9s/noarch/python3-eventlet-0.30.2-1.el9s.noarch.rpm
 RUN dnf install -y python3-s3fuse-plugin-el9
 
+## Explicitly pin iscsi-initiator-utils to 6.2.1.9 (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
+RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" || \
+    dnf install -y --allowerasing "iscsi-initiator-utils-6.2.1.9*" "iscsi-initiator-utils-iscsiuio-6.2.1.9*"
+
 ## Copy locally built virt-v2v-in-place binary
 COPY virt-v2v-in-place /usr/local/bin/
 

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
@@ -44,10 +44,11 @@ RUN dnf install -y --allowerasing --exclude=iscsi-initiator-utils\* \
     https://cbs.centos.org/kojifiles/packages/python-eventlet/0.30.2/1.el9s/noarch/python3-eventlet-0.30.2-1.el9s.noarch.rpm
 RUN dnf install -y --exclude=iscsi-initiator-utils\* python3-s3fuse-plugin-el9
 
-## Verify iscsi-initiator-utils is 6.2.1.9 from the base image (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
-## Rocky repos no longer carry 6.2.1.9; we preserve it by excluding it from all dnf steps above.
-RUN rpm -q iscsi-initiator-utils | grep -q "6.2.1.9" \
-    || { rpm -q iscsi-initiator-utils; echo "FATAL: iscsi-initiator-utils is not 6.2.1.9"; exit 1; }
+## Explicitly install iscsi-initiator-utils 6.2.1.9 from Rocky 9.4 vault (TVAULT-7336: 6.2.1.11 breaks iSCSI portal login)
+## Rocky current repos only carry 6.2.1.11; pin to 6.2.1.9 from the vault with --allowerasing to downgrade if needed.
+RUN dnf install -y --allowerasing \
+    https://dl.rockylinux.org/vault/rocky/9.4/BaseOS/x86_64/os/Packages/i/iscsi-initiator-utils-6.2.1.9-1.gita65a472.el9.x86_64.rpm \
+    https://dl.rockylinux.org/vault/rocky/9.4/BaseOS/x86_64/os/Packages/i/iscsi-initiator-utils-iscsiuio-6.2.1.9-1.gita65a472.el9.x86_64.rpm
 
 ## Copy locally built virt-v2v-in-place binary
 COPY virt-v2v-in-place /usr/local/bin/

--- a/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
+++ b/docker/kolla-ansible/trilio-datamover/Dockerfile_2025.1_rocky
@@ -20,8 +20,9 @@ RUN dnf config-manager --save --setopt=epel.skip_if_unavailable=true
 ADD trilio.repo /etc/yum.repos.d/
 
 ##Install Required Packages
+# Exclude iscsi-initiator-utils from update: 6.2.1.11 breaks iSCSI portal login; keep 6.2.1.9 from base image (TVAULT-7336)
 RUN set -ex \
-    && dnf update -y
+    && dnf update -y --exclude=iscsi-initiator-utils\*
 
 ##Add nova user into the disk and kvm group
 RUN usermod -u 42436 nova && groupmod -g 42436 nova && usermod -aG disk,libvirt,kolla,kvm nova


### PR DESCRIPTION
## Summary
- `dnf update -y` in `Dockerfile_2025.1_rocky` (kolla Epoxy datamover) was upgrading `iscsi-initiator-utils` from `6.2.1.9` to `6.2.1.11`
- `6.2.1.11` fails to login to iSCSI portals; the nova-compute container ships `6.2.1.9` which works correctly
- Fix: add `--exclude=iscsi-initiator-utils*` to `dnf update` to preserve the working base-image version

## Test plan
- [ ] Build the `kolla-rocky-trilio-datamover:*-2025.1` image and verify `iscsid --version` reports `6.2.1.9`
- [ ] Create an instance with an LVM/iSCSI volume, create a workload, trigger a snapshot and confirm it completes successfully on Kolla Epoxy (Rocky 9)

Fixes: TVAULT-7336