### PR TITLE
TVAULT-7328: set amqp_durable_queues based on rabbit_quorum_queue in datamover and dmapi conf

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
@@ -35,6 +35,7 @@ auth_uri = {{ .Values.keystone.common.auth_uri }}
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+amqp_durable_queues = {{ if .Values.rabbitmq.cluster.rabbit_quorum_queue }}true{{ else }}false{{ end }}
 
 [oslo_messaging_notifications]
 driver = {{ .Values.rabbitmq.common.driver }}

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
@@ -68,4 +68,5 @@ helper_command = sudo /usr/bin/workloadmgr-rootwrap /etc/triliovault-wlm/rootwra
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+amqp_durable_queues = {{ if .Values.rabbitmq.cluster.rabbit_quorum_queue }}true{{ else }}false{{ end }}
 

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
@@ -20,7 +20,7 @@ keyring_ext = .keyring
 [oslo_messaging_rabbit]
 rabbit_quorum_queue = {{ rabbit_quorum_queue }}
 ssl = {{ rabbit_ssl }}
-amqp_durable_queues = false
+amqp_durable_queues = {{ 'true' if rabbit_quorum_queue | bool else 'false' }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [dmapi_database]


### PR DESCRIPTION
## Summary
- mqp_durable_queues is now set dynamically based on abbit_quorum_queue in 	riliovault-datamover.conf, 	riliovault-datamover-api.conf, and 	riliovault-wlm.conf
- abbit_quorum_queue = true -> mqp_durable_queues = true
- abbit_quorum_queue = false -> mqp_durable_queues = false

## Problem
With quorum queues enabled, the contego_fanout exchange in the dmapi RabbitMQ vhost was being declared with mismatched durability properties, causing a PRECONDITION_FAILED (406) error and preventing the 	riliovault_datamover container from starting.

## Changes
- edhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2: replaced static alse with Jinja2 ternary
- edhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl: added mqp_durable_queues with Helm conditional
- edhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl: added mqp_durable_queues with Helm conditional

## Test plan
- [ ] Deploy with abbit_quorum_queue: true -- confirm mqp_durable_queues = true in generated conf files and datamover container starts cleanly
- [ ] Deploy with abbit_quorum_queue: false -- confirm mqp_durable_queues = false in generated conf files

Backport of: https://github.com/trilioData/triliovault-cfg-scripts/pull/1416