### PR TITLE
TVAULT-7345: add nova-sudoers to kolla-ansible WLM container images

### DIFF
--- a/docker/kolla-ansible/devops-build-publish.sh
+++ b/docker/kolla-ansible/devops-build-publish.sh
@@ -8,29 +8,25 @@
 #   bash devops-build-publish.sh <tag> <os_platform> [container]
 #
 # Arguments:
-#   tag          Docker image tag (any format), e.g. 5.2.7-2025.1
+#   tag          Docker image tag (any format), e.g. 6.2.0-2025.1
 #   os_platform  OS platform: rocky | ubuntu
 #   container    (optional) Build only this container:
 #                  trilio-datamover | trilio-datamover-api |
 #                  trilio-horizon-plugin | trilio-wlm | trilio-dms
 #                If omitted, all 5 containers are built.
 #
-# Environment variables (required):
-#   RPM_REPO_URL   Trilio RPM repo baseurl  (rocky builds)
-#   DEB_REPO_URL   Trilio APT repo line     (ubuntu builds)
-#   PIP_REPO_URL   Trilio pip index URL     (horizon-plugin on both platforms)
-#
 # Examples:
-#   RPM_REPO_URL='https://...' PIP_REPO_URL='https://...' bash devops-build-publish.sh 5.2.7-2025.1 rocky
-#   DEB_REPO_URL='deb https://...' PIP_REPO_URL='https://...' bash devops-build-publish.sh 5.2.7-2025.1 ubuntu
-#   RPM_REPO_URL='https://...' PIP_REPO_URL='https://...' bash devops-build-publish.sh 5.2.7-2025.1 rocky trilio-datamover
+#   bash devops-build-publish.sh 6.2.0-2025.1 rocky
+#   bash devops-build-publish.sh 6.2.0-2025.1 ubuntu
+#   bash devops-build-publish.sh 6.2.0-2025.1 rocky trilio-datamover
+#   bash devops-build-publish.sh 6.2.0-2025.1 rocky trilio-dms
 #
 # Published image format:
 #   docker.io/trilio/kolla-<platform>-<container>:<tag>
-#   e.g. docker.io/trilio/kolla-rocky-trilio-datamover:5.2.7-2025.1
-#        docker.io/trilio/kolla-ubuntu-trilio-datamover:5.2.7-2025.1
-#        docker.io/trilio/kolla-rocky-trilio-dms:5.2.7-2025.1
-#        docker.io/trilio/kolla-ubuntu-trilio-dms:5.2.7-2025.1
+#   e.g. docker.io/trilio/kolla-rocky-trilio-datamover:6.2.0-2025.1
+#        docker.io/trilio/kolla-ubuntu-trilio-datamover:6.2.0-2025.1
+#        docker.io/trilio/kolla-rocky-trilio-dms:6.2.0-2025.1
+#        docker.io/trilio/kolla-ubuntu-trilio-dms:6.2.0-2025.1
 
 set -e
 
@@ -38,7 +34,7 @@ usage() {
     cat <<EOF
 Usage: $0 <tag> <os_platform> [container]
 
-  tag          Docker image tag (any format), e.g. 5.2.7-2025.1
+  tag          Docker image tag (any format), e.g. 6.2.0-2025.1
   os_platform  OS platform to build for: rocky | ubuntu
   container    (optional) Build and publish a single container.
                If omitted, all 5 containers are built.
@@ -54,10 +50,10 @@ Published image format:
   docker.io/trilio/kolla-<platform>-<container>:<tag>
 
 Examples:
-  $0 5.2.7-2025.1 rocky
-  $0 5.2.7-2025.1 ubuntu
-  $0 5.2.7-2025.1 rocky trilio-datamover
-  $0 5.2.7-2025.1 rocky trilio-dms
+  $0 6.2.0-2025.1 rocky
+  $0 6.2.0-2025.1 ubuntu
+  $0 6.2.0-2025.1 rocky trilio-datamover
+  $0 6.2.0-2025.1 rocky trilio-dms
 
 Options:
   -h, --help   Show this help message and exit.
@@ -78,6 +74,7 @@ TAG="$1"
 PLATFORM="$2"
 SINGLE_CONTAINER="${3:-}"
 OPENSTACK_RELEASE="2025.1"
+TRILIO_PIP_INDEX_URL="https://pypi.fury.io/trilio-6-2/"
 
 case "$PLATFORM" in
     rocky|ubuntu) ;;
@@ -86,21 +83,6 @@ case "$PLATFORM" in
         exit 1
         ;;
 esac
-
-# Repo URLs must be supplied via environment variables — read from the
-# "Latest Build Details" Confluence page for the matching T4O release.
-if [ "$PLATFORM" = "rocky" ] && [ -z "${RPM_REPO_URL:-}" ]; then
-    echo "ERROR: RPM_REPO_URL env var is required for rocky builds."
-    exit 1
-fi
-if [ "$PLATFORM" = "ubuntu" ] && [ -z "${DEB_REPO_URL:-}" ]; then
-    echo "ERROR: DEB_REPO_URL env var is required for ubuntu builds."
-    exit 1
-fi
-if [ -z "${PIP_REPO_URL:-}" ]; then
-    echo "ERROR: PIP_REPO_URL env var is required (used for horizon-plugin)."
-    exit 1
-fi
 
 ALL_CONTAINERS=(trilio-datamover trilio-datamover-api trilio-horizon-plugin trilio-wlm trilio-dms)
 if [ -n "$SINGLE_CONTAINER" ]; then
@@ -168,15 +150,10 @@ for CONTAINER in "${OS_CONTAINERS[@]}"; do
     cp "$SOURCE_DF" "$CONT_BUILD_DIR/Dockerfile"
     rm -f "$CONT_BUILD_DIR/Dockerfile_"*
 
-    # Substitute repo URL placeholders
-    if [ "$PLATFORM" = "rocky" ] && [ -f "$CONT_BUILD_DIR/trilio.repo" ]; then
-        sed -i "s|{RPM_REPO_URL}|${RPM_REPO_URL}|g" "$CONT_BUILD_DIR/trilio.repo"
+    BUILD_ARGS=""
+    if [ "$CONTAINER" = "trilio-horizon-plugin" ]; then
+        BUILD_ARGS="--build-arg TRILIO_PIP_INDEX_URL=${TRILIO_PIP_INDEX_URL}"
     fi
-    if [ "$PLATFORM" = "ubuntu" ] && [ -f "$CONT_BUILD_DIR/trilio.list" ]; then
-        sed -i "s|{DEB_REPO_URL}|${DEB_REPO_URL}|g" "$CONT_BUILD_DIR/trilio.list"
-    fi
-
-    BUILD_ARGS="--build-arg TRILIO_PIP_INDEX_URL=${PIP_REPO_URL}"
 
     docker build --no-cache --pull --network host $BUILD_ARGS -t "$IMAGE" "$CONT_BUILD_DIR"
     docker push "$IMAGE"
@@ -203,13 +180,6 @@ if [ -z "$SINGLE_CONTAINER" ] || [ "$SINGLE_CONTAINER" = "trilio-dms" ]; then
         cp -R "$BASE_DIR/trilio-dms" "$DMS_BUILD_DIR"
         cp "$DMS_SOURCE_DF" "$DMS_BUILD_DIR/Dockerfile"
         rm -f "$DMS_BUILD_DIR/Dockerfile_"*
-
-        if [ "$PLATFORM" = "rocky" ] && [ -f "$DMS_BUILD_DIR/trilio.repo" ]; then
-            sed -i "s|{RPM_REPO_URL}|${RPM_REPO_URL}|g" "$DMS_BUILD_DIR/trilio.repo"
-        fi
-        if [ "$PLATFORM" = "ubuntu" ] && [ -f "$DMS_BUILD_DIR/trilio.list" ]; then
-            sed -i "s|{DEB_REPO_URL}|${DEB_REPO_URL}|g" "$DMS_BUILD_DIR/trilio.list"
-        fi
 
         docker build --no-cache --pull --network host -t "$DMS_IMAGE" "$DMS_BUILD_DIR"
         docker push "$DMS_IMAGE"

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_rocky
@@ -52,6 +52,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_rocky
@@ -53,6 +53,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_ubuntu
@@ -43,6 +43,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.1_ubuntu
@@ -42,6 +42,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_rocky
@@ -52,6 +52,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_rocky
@@ -53,6 +53,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_ubuntu
@@ -43,6 +43,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2023.2_ubuntu
@@ -42,6 +42,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_rocky
@@ -52,6 +52,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_rocky
@@ -53,6 +53,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_ubuntu
@@ -43,6 +43,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2024.1_ubuntu
@@ -42,6 +42,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_rocky
@@ -60,6 +60,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_rocky
@@ -61,6 +61,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_ubuntu
@@ -50,6 +50,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.1_ubuntu
@@ -51,6 +51,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_rocky
@@ -61,6 +61,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_rocky
@@ -60,6 +60,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_ubuntu
@@ -50,6 +50,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_2025.2_ubuntu
@@ -51,6 +51,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_centos
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_centos
@@ -40,6 +40,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_centos
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_centos
@@ -41,6 +41,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_ubuntu
@@ -37,6 +37,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_wallaby_ubuntu
@@ -38,6 +38,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_centos
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_centos
@@ -41,6 +41,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_centos
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_centos
@@ -40,6 +40,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_ubuntu
@@ -39,6 +39,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_yoga_ubuntu
@@ -38,6 +38,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_rocky
@@ -52,6 +52,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_rocky
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_rocky
@@ -53,6 +53,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store  /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_ubuntu
@@ -43,6 +43,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
 ADD nova-sudoers /etc/sudoers.d/nova-sudoers
+RUN ln -s /usr/bin/workloadmgr-rootwrap /var/lib/kolla/venv/bin/workloadmgr-rootwrap
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_ubuntu
+++ b/docker/kolla-ansible/trilio-wlm/Dockerfile_zed_ubuntu
@@ -42,6 +42,7 @@ RUN chown -R nova:nova /var/log/triliovault /var/trilio /var/trilio/triliovault-
     && chown -R root:nova /etc/triliovault-wlm /etc/triliovault-object-store 
 RUN chmod -R 755 /var/log/triliovault /etc/triliovault-wlm /etc/triliovault-object-store /var/lib/workloadmgr \
     && chmod -R 777 /var/trilio/triliovault-mounts /var/triliovault
+ADD nova-sudoers /etc/sudoers.d/nova-sudoers
 
 ## Kolla specific settings
 COPY extend_start.sh /usr/local/bin/kolla_extend_start

--- a/docker/kolla-ansible/trilio-wlm/nova-sudoers
+++ b/docker/kolla-ansible/trilio-wlm/nova-sudoers
@@ -1,2 +1,1 @@
 nova ALL = (root) NOPASSWD: /usr/bin/workloadmgr-rootwrap *
-nova ALL = (root) NOPASSWD: /var/lib/kolla/venv/bin/workloadmgr-rootwrap *

--- a/docker/kolla-ansible/trilio-wlm/nova-sudoers
+++ b/docker/kolla-ansible/trilio-wlm/nova-sudoers
@@ -1,0 +1,2 @@
+nova ALL = (root) NOPASSWD: /usr/bin/workloadmgr-rootwrap *
+nova ALL = (root) NOPASSWD: /var/lib/kolla/venv/bin/workloadmgr-rootwrap *


### PR DESCRIPTION
## Summary
- File search was failing in Kolla with `sudo: a terminal is required to read the password` because the nova user had no passwordless sudo rule for `workloadmgr-rootwrap`
- `filesearch.py` runs `modprobe nbd` via `sudo workloadmgr-rootwrap`, but without a NOPASSWD sudoers entry the command fails in a non-interactive container environment
- Added `nova-sudoers` to the trilio-wlm image (all OpenStack versions) granting NOPASSWD for both `/usr/bin/workloadmgr-rootwrap` and `/var/lib/kolla/venv/bin/workloadmgr-rootwrap` (the path resolved by filesearch.py from the kolla venv Python prefix), mirroring the existing pattern used by the datamover image for `privsep-helper`

## Test plan
- [ ] Build the Kolla Rocky Epoxy (2025.1) WLM image and verify it builds successfully
- [ ] Deploy on a Kolla Rocky Epoxy test environment and verify file search works end-to-end
- [ ] Confirm no `sudo: a terminal is required` error in wlm-workloads.log during file search