### PR TITLE
TVAULT-7263: Add back wlm-cloud-trust job in RHOSO18 DevOps

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-wlm-cloud-trust.sh.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-wlm-cloud-trust.sh.tpl
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+source /tmp/triliovault-cloudrc
+export OS_PROJECT_ID=$(openstack project show -f value -c id "${OS_PROJECT_NAME}")
+
+sleep 2m
+for attempt in {1..10};
+do
+        echo -e "Attempting to create wlm-cloud admin trust, Attempt Number: $attempt"
+        command_output=$(workloadmgr trust-create --is_cloud_trust True admin --insecure 2>&1)
+        status=$?
+        echo "Command output: $command_output"
+        if echo "$command_output" | grep -q "unavailable"; then
+            echo -e "wlm cloud admin trust create command failed due to wlm service unavailability. Will re-try after 30 seconds"
+            sleep 30s
+            continue
+        elif [ $status -eq 0 ]; then
+            echo -e "wlm cloud admin trust created successfully"
+            break
+        else
+            echo -e "wlm cloud admin trust creation failed, re-trying"
+            sleep 30s
+            continue
+        fi
+done

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/workloadmgr/configmap-bin-wlm.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/workloadmgr/configmap-bin-wlm.yaml
@@ -16,6 +16,8 @@ data:
 {{ tpl (.Files.Get "scripts/_triliovault-wlm-scheduler.sh.tpl") . | indent 4 }}
   triliovault-wlm-workloads.sh: |
 {{ tpl (.Files.Get "scripts/_triliovault-wlm-workloads.sh.tpl") . | indent 4 }}
+  triliovault-wlm-cloud-trust.sh: |
+{{ tpl (.Files.Get "scripts/_triliovault-wlm-cloud-trust.sh.tpl") . | indent 4 }}
   triliovault-wlm-keystone-init.sh: |-
 {{ tpl (.Files.Get "scripts/_triliovault-wlm-keystone-init.sh.tpl") . | indent 4 }}
   triliovault-wlm-db-init.sh: |-

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/workloadmgr/job-wlm-cloud-trust.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/workloadmgr/job-wlm-cloud-trust.yaml
@@ -1,0 +1,86 @@
+{{- if eq .Values.crdType "TVOControlPlane" }}
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: job-triliovault-wlm-cloud-trust
+  labels:
+    application: triliovault
+    component: wlm-cloud-trust
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "150"
+spec:
+  backoffLimit: 1000
+  template:
+    metadata:
+      labels:
+        application: triliovault
+        component: wlm-cloud-trust
+    spec:
+      securityContext:
+        runAsUser: {{ .Values.common.nova_user_id }}
+        fsGroup: {{ .Values.common.nova_group_id }}
+      serviceAccountName: triliovault-wlm
+      restartPolicy: OnFailure
+      nodeSelector:
+        trilio-control-plane: enabled
+      containers:
+        - name: "wlm-cloud-trust-creation"
+          securityContext:
+            readOnlyRootFilesystem: false
+            runAsUser: {{ .Values.common.nova_user_id }}
+          image: {{ .Values.images.triliovault_wlm_api }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: openstack-secret
+                  key: CloudAdminPassword
+          command:
+            - /bin/bash
+            - -c
+            - /tmp/triliovault-wlm-cloud-trust.sh
+          volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
+            - name: triliovault-wlm-bin
+              mountPath: /tmp/triliovault-cloudrc
+              subPath: triliovault-cloudrc
+            - name: triliovault-wlm-bin
+              mountPath: /tmp/triliovault-wlm-cloud-trust.sh
+              subPath: triliovault-wlm-cloud-trust.sh
+            - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+              name: combined-ca-bundle
+              readOnly: true
+              subPath: tls-ca-bundle.pem
+      volumes:
+        - name: pod-tmp
+          emptyDir: {}
+        - name: triliovault-wlm-bin
+          configMap:
+            name: "triliovault-wlm-bin"
+            defaultMode: 0555
+        - name: triliovault-wlm-etc
+          secret:
+            secretName: triliovault-wlm-etc
+            defaultMode: 0444
+        - name: combined-ca-bundle
+          secret:
+            defaultMode: 292
+            secretName: combined-ca-bundle
+{{- end }}


### PR DESCRIPTION
## Summary
- Restores the `wlm-cloud-trust` Helm job that was inadvertently removed from the RHOSO18 `tvo-chart`
- Re-adds the job template (`job-wlm-cloud-trust.yaml`), its shell script (`_triliovault-wlm-cloud-trust.sh.tpl`), and the `configmap-bin-wlm` entry
- Users no longer need to create the cloud trust manually after deployment

## Test plan
- [ ] Deploy T4O on RHOSO18 and verify the `wlm-cloud-trust` job runs successfully post-install
- [ ] Confirm cloud trust is created automatically without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)