### PR TITLE
TVAULT-7366: Collect S3 secret key in plain text during collect phase

### DIFF
--- a/kolla-ansible/ansible/create_backup_target_62.yml
+++ b/kolla-ansible/ansible/create_backup_target_62.yml
@@ -16,10 +16,6 @@
 #
 # Usage:
 #   ansible-playbook -i <INVENTORY> create_backup_target_62.yml
-#
-# For S3 targets, supply the secret key via env var or extra var:
-#   export TRILIOVAULT_S3_SECRET_KEY=<key>
-#   -e triliovault_s3_secret_key=<key>
 
 - name: Create T4O 6.2 backup target
   hosts: "{{ (groups[triliovault_wlm_api_group | default('triliovault-wlm-api')] | first) }}"
@@ -59,26 +55,6 @@
       become: true
       when: bt_data.backup_target.type | lower == 'nfs'
 
-    - name: Set S3 secret key
-      set_fact:
-        s3_secret_key: >-
-          {{
-            triliovault_s3_secret_key
-            if triliovault_s3_secret_key is defined and triliovault_s3_secret_key != ''
-            else lookup('env', 'TRILIOVAULT_S3_SECRET_KEY')
-          }}
-      no_log: true
-      when: bt_data.backup_target.type | lower in ['amazon_s3', 'other_s3_compatible']
-
-    - name: Fail if S3 secret key not provided
-      fail:
-        msg: >
-          S3 secret key is required. Either export TRILIOVAULT_S3_SECRET_KEY
-          or pass -e triliovault_s3_secret_key=<key>.
-      when:
-        - bt_data.backup_target.type | lower in ['amazon_s3', 'other_s3_compatible']
-        - s3_secret_key | default('') == ''
-
     - name: Create S3 backup target
       shell: |
         set -a; source {{ cloudrc }}; set +a
@@ -92,7 +68,7 @@
             --name "{{ bt_name }}" \
             --type "{{ bt_data.backup_target.type }}" \
             --s3-access-key "{{ bt_data.backup_target.s3_access_key }}" \
-            --s3-secret-key "{{ s3_secret_key }}" \
+            --s3-secret-key "{{ bt_data.backup_target.s3_secret_key }}" \
             --s3-bucket-name "{{ bt_data.backup_target.s3_bucket }}" \
             --s3-region "{{ bt_data.backup_target.s3_region | default('us-east-1') }}" \
             {% if bt_data.backup_target.s3_endpoint | default('') %}

--- a/kolla-ansible/ansible/create_backup_target_62.yml
+++ b/kolla-ansible/ansible/create_backup_target_62.yml
@@ -51,7 +51,7 @@
           -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
           -e OS_PROJECT_NAME -e OS_PROJECT_ID \
           -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
-          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE -e OS_CACERT \
           {{ wlm_container }} \
           workloadmgr backup-target-create \
             --btt-name "{{ bt_name }}" \
@@ -83,7 +83,7 @@
           -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
           -e OS_PROJECT_NAME -e OS_PROJECT_ID \
           -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
-          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE -e OS_CACERT \
           {{ wlm_container }} \
           trilio-dms-cli secret-payload create \
             --access-key "{{ bt_data.backup_target.s3_access_key }}" \
@@ -104,7 +104,7 @@
           -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
           -e OS_PROJECT_NAME -e OS_PROJECT_ID \
           -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
-          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE -e OS_CACERT \
           {{ wlm_container }} \
           openstack secret store \
             --name "secret-key-{{ bt_name }}" \
@@ -123,7 +123,7 @@
           -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
           -e OS_PROJECT_NAME -e OS_PROJECT_ID \
           -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
-          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_CACERT \
           -e OS_INTERFACE=public \
           {{ wlm_container }} \
           openstack endpoint list \
@@ -150,7 +150,7 @@
           -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
           -e OS_PROJECT_NAME -e OS_PROJECT_ID \
           -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
-          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE -e OS_CACERT \
           {{ wlm_container }} \
           workloadmgr backup-target-create \
             --btt-name "{{ bt_name }}" \
@@ -173,7 +173,7 @@
           -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
           -e OS_PROJECT_NAME -e OS_PROJECT_ID \
           -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
-          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE -e OS_CACERT \
           {{ wlm_container }} \
           workloadmgr backup-target-list
       become: true

--- a/kolla-ansible/ansible/create_backup_target_62.yml
+++ b/kolla-ansible/ansible/create_backup_target_62.yml
@@ -9,10 +9,14 @@
 # Reads backup target config from existing_backup_targets.yaml produced by
 # collect_backup_targets.sh (run BEFORE the upgrade).
 #
-# workloadmgr executes inside the triliovault_wlm_api container on the
-# controller node. Cloud admin credentials are sourced from the rendered
-# triliovault-cloudrc file at /etc/kolla/triliovault-cloudrc (produced by
-# the deploy/config step via get_cloud_details.yml).
+# For NFS targets, workloadmgr is called directly with the updated argument
+# names introduced in T4O 6.2.
+#
+# For S3 targets, credentials are stored in OpenStack Barbican using
+# trilio-dms-cli before the backup target is created. trilio-dms-cli and
+# openstack CLI run inside the triliovault_wlm_api container via docker exec.
+# The Barbican secret href is normalised to the public endpoint before being
+# passed to workloadmgr.
 #
 # Usage:
 #   ansible-playbook -i <INVENTORY> create_backup_target_62.yml
@@ -37,6 +41,9 @@
       set_fact:
         bt_name: "{{ 'nfs' if bt_data.backup_target.type | lower == 'nfs' else 's3' }}-backup-target-1"
 
+    # -----------------------------------------------------------------------
+    # NFS backup target
+    # -----------------------------------------------------------------------
     - name: Create NFS backup target
       shell: |
         set -a; source {{ cloudrc }}; set +a
@@ -47,15 +54,50 @@
           -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
           {{ wlm_container }} \
           workloadmgr backup-target-create \
-            --name "{{ bt_name }}" \
+            --btt-name "{{ bt_name }}" \
             --type nfs \
-            --nfs-shares "{{ bt_data.backup_target.nfs_shares }}" \
-            --nfs-options "{{ bt_data.backup_target.nfs_options | default('nolock,soft,timeo=180,intr,lookupcache=none') }}" \
-            --is-default true
+            --filesystem-export "{{ bt_data.backup_target.nfs_shares }}" \
+            --nfs-mount-opts "{{ bt_data.backup_target.nfs_options | default('nolock,soft,timeo=180,intr,lookupcache=none') }}" \
+            --default
       become: true
       when: bt_data.backup_target.type | lower == 'nfs'
 
-    - name: Create S3 backup target
+    # -----------------------------------------------------------------------
+    # S3 backup target — credentials are stored in Barbican before creation.
+    #
+    # Flow:
+    #   1. trilio-dms-cli creates an encrypted secret payload in the container
+    #   2. openstack secret store saves it to Barbican (inside container)
+    #   3. openstack endpoint list resolves the public Barbican URL
+    #   4. Secret href is normalised to the public endpoint
+    #   5. workloadmgr backup-target-create uses --secret-ref
+    # -----------------------------------------------------------------------
+    - name: Create S3 secret payload via trilio-dms-cli
+      shell: |
+        set -a; source {{ cloudrc }}; set +a
+        ENDPOINT_FLAG=""
+        if [ -n "{{ bt_data.backup_target.s3_endpoint | default('') }}" ]; then
+          ENDPOINT_FLAG="--endpoint-url {{ bt_data.backup_target.s3_endpoint }}"
+        fi
+        docker exec \
+          -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
+          -e OS_PROJECT_NAME -e OS_PROJECT_ID \
+          -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
+          {{ wlm_container }} \
+          trilio-dms-cli secret-payload create \
+            --access-key "{{ bt_data.backup_target.s3_access_key }}" \
+            --secret-key "{{ bt_data.backup_target.s3_secret_key }}" \
+            --bucket "{{ bt_data.backup_target.s3_bucket }}" \
+            $ENDPOINT_FLAG \
+            -o /tmp/bt_secret.json
+        docker cp {{ wlm_container }}:/tmp/bt_secret.json /tmp/triliovault_bt_secret.json
+        docker exec {{ wlm_container }} rm -f /tmp/bt_secret.json
+      become: true
+      no_log: true
+      when: bt_data.backup_target.type | lower in ['amazon_s3', 'other_s3_compatible']
+
+    - name: Store S3 credentials in Barbican
       shell: |
         set -a; source {{ cloudrc }}; set +a
         docker exec \
@@ -64,21 +106,66 @@
           -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
           -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
           {{ wlm_container }} \
+          openstack secret store \
+            --name "secret-key-{{ bt_name }}" \
+            --payload "$(cat /tmp/triliovault_bt_secret.json)" \
+            -f json
+        rm -f /tmp/triliovault_bt_secret.json
+      become: true
+      no_log: true
+      register: barbican_secret_result
+      when: bt_data.backup_target.type | lower in ['amazon_s3', 'other_s3_compatible']
+
+    - name: Resolve public Barbican endpoint
+      shell: |
+        set -a; source {{ cloudrc }}; set +a
+        docker exec \
+          -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
+          -e OS_PROJECT_NAME -e OS_PROJECT_ID \
+          -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME \
+          -e OS_INTERFACE=public \
+          {{ wlm_container }} \
+          openstack endpoint list \
+            --service key-manager --interface public -f value -c URL
+      become: true
+      register: barbican_public_raw
+      when: bt_data.backup_target.type | lower in ['amazon_s3', 'other_s3_compatible']
+
+    - name: Build normalised Barbican secret ref
+      set_fact:
+        s3_secret_ref: >-
+          {{ (barbican_public_raw.stdout_lines[0] | trim) | regex_replace('/v1$', '') }}/v1/secrets/{{ (barbican_secret_result.stdout | from_json)['Secret href'].split('/') | last }}
+      no_log: true
+      when: bt_data.backup_target.type | lower in ['amazon_s3', 'other_s3_compatible']
+
+    - name: Create S3 backup target
+      shell: |
+        set -a; source {{ cloudrc }}; set +a
+        ENDPOINT_FLAG=""
+        if [ -n "{{ bt_data.backup_target.s3_endpoint | default('') }}" ]; then
+          ENDPOINT_FLAG="--s3-endpoint-url {{ bt_data.backup_target.s3_endpoint }}"
+        fi
+        docker exec \
+          -e OS_AUTH_URL -e OS_USERNAME -e OS_PASSWORD \
+          -e OS_PROJECT_NAME -e OS_PROJECT_ID \
+          -e OS_USER_DOMAIN_NAME -e OS_PROJECT_DOMAIN_ID \
+          -e OS_IDENTITY_API_VERSION -e OS_REGION_NAME -e OS_INTERFACE \
+          {{ wlm_container }} \
           workloadmgr backup-target-create \
-            --name "{{ bt_name }}" \
+            --btt-name "{{ bt_name }}" \
             --type "{{ bt_data.backup_target.type }}" \
-            --s3-access-key "{{ bt_data.backup_target.s3_access_key }}" \
-            --s3-secret-key "{{ bt_data.backup_target.s3_secret_key }}" \
-            --s3-bucket-name "{{ bt_data.backup_target.s3_bucket }}" \
-            --s3-region "{{ bt_data.backup_target.s3_region | default('us-east-1') }}" \
-            {% if bt_data.backup_target.s3_endpoint | default('') %}
-            --s3-endpoint-url "{{ bt_data.backup_target.s3_endpoint }}" \
-            {% endif %}
-            --is-default true
+            --s3-bucket "{{ bt_data.backup_target.s3_bucket }}" \
+            $ENDPOINT_FLAG \
+            --secret-ref "{{ s3_secret_ref }}" \
+            --default
       become: true
       no_log: true
       when: bt_data.backup_target.type | lower in ['amazon_s3', 'other_s3_compatible']
 
+    # -----------------------------------------------------------------------
+    # Verify
+    # -----------------------------------------------------------------------
     - name: Verify backup target list
       shell: |
         set -a; source {{ cloudrc }}; set +a

--- a/kolla-ansible/ansible/scripts/collect_backup_targets.sh
+++ b/kolla-ansible/ansible/scripts/collect_backup_targets.sh
@@ -4,7 +4,7 @@
 # Reads T4O 5.2 backup target configuration from globals.yml and saves it
 # to existing_backup_targets.yaml BEFORE upgrading to T4O 6.2.
 #
-# This file is used as input for upgrade_backup_target_62.sh after the upgrade.
+# This file is used as input for create_backup_target_62.yml after the upgrade.
 # It must be run before the upgrade because cleanup_backup_targets.yml removes
 # backup target variables from globals.yml as part of the upgrade cleanup.
 #
@@ -23,9 +23,6 @@
 #
 # Output:
 #   existing_backup_targets.yaml  (path overridable with -o)
-#
-# NOTE: The S3 secret key (triliovault_s3_secret_key) is written REDACTED.
-#       You will be prompted to enter it when running upgrade_backup_target_62.sh.
 
 set -e
 
@@ -85,7 +82,7 @@ if bt_type.lower() == 'nfs':
 
 elif bt_type.lower() in ('amazon_s3', 'other_s3_compatible'):
     config['s3_access_key']          = d.get('triliovault_s3_access_key', '')
-    config['s3_secret_key']          = 'REDACTED'
+    config['s3_secret_key']          = d.get('triliovault_s3_secret_key', '')
     config['s3_bucket']              = d.get('triliovault_s3_bucket_name', '')
     config['s3_region']              = d.get('triliovault_s3_region_name', 'us-east-1')
     config['s3_endpoint']            = d.get('triliovault_s3_endpoint_url', '')
@@ -96,7 +93,7 @@ elif bt_type.lower() in ('amazon_s3', 'other_s3_compatible'):
     config['s3_ssl_cert_file_name']  = d.get('triliovault_s3_ssl_cert_file_name', '')
     config['copy_ceph_s3_ssl_cert']  = d.get('triliovault_copy_ceph_s3_ssl_cert', False)
     print("  S3 access key      : " + str(config['s3_access_key']))
-    print("  S3 secret key      : REDACTED (enter manually during upgrade_backup_target_62.sh)")
+    print("  S3 secret key      : " + ("(set)" if config['s3_secret_key'] else "(empty)"))
     print("  S3 bucket          : " + str(config['s3_bucket']))
     print("  S3 region          : " + str(config['s3_region']))
     print("  S3 endpoint        : " + str(config['s3_endpoint'] or '(default)'))
@@ -116,9 +113,6 @@ with open(output_path, 'w') as f:
     f.write("# T4O 5.2 Backup Target Configuration\n")
     f.write("# Collected before upgrade to T4O 6.2\n")
     f.write("#\n")
-    f.write("# IMPORTANT: S3 secret key is REDACTED. You will be prompted for it\n")
-    f.write("# when running upgrade_backup_target_62.sh after the upgrade.\n")
-    f.write("#\n")
     yaml.dump(output, f, default_flow_style=False, allow_unicode=True)
 
 print("  Written: " + output_path)
@@ -130,4 +124,4 @@ log ""
 log "Next steps:"
 log "  1. Upgrade to T4O 6.2:  kolla-ansible upgrade --tags triliovault"
 log "  2. Run cleanup:          ansible-playbook cleanup_backup_targets.yml --tags upgrade-and-clean-backup-target-mounts"
-log "  3. Re-create BT:         bash upgrade_backup_target_62.sh -f $OUTPUT --openrc /etc/kolla/admin-openrc.sh"
+log "  3. Re-create BT:         ansible-playbook -i <INVENTORY> create_backup_target_62.yml"


### PR DESCRIPTION
collect_backup_targets.sh now reads triliovault_s3_secret_key from globals.yml and writes it to existing_backup_targets.yaml instead of storing REDACTED. create_backup_target_62.yml reads the key directly from the collected YAML - no env var or extra-var prompt needed.