### PR TITLE
TVAULT-7361: kolla-ansible: use workloadmgr db for dmapi DMS client

### DIFF
--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-client-dmapi.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-client-dmapi.conf.j2
@@ -1,7 +1,7 @@
 [client]
 rabbitmq_url = rabbit://openstack:{{ om_rpc_password }}@{{ hostvars[groups[om_rpc_group][0]]['ansible_' + hostvars[groups[om_rpc_group][0]]['api_interface']]['ipv4']['address'] }}:{{ rabbitmq_port }}//
 
-db_url = mysql+pymysql://{{ triliovault_db_details[0].database_user }}:{{ triliovault_datamover_database_password }}@{{ triliovault_db_details[0].database_address }}/{{ triliovault_db_details[0].database_name }}
+db_url = mysql+pymysql://{{ triliovault_db_details[1].database_user }}:{{ triliovault_wlm_database_password }}@{{ triliovault_db_details[1].database_address }}/{{ triliovault_db_details[1].database_name }}
 
 request_timeout = 60
 log_level = INFO


### PR DESCRIPTION
## Summary
- The DMS client config for `dmapi` was pointing to the `dmapi` database.
- Changed it to use the shared `workloadmgr` database (same as WLM services) so DMS mount state is tracked in a single place.
- Without this fix, physical BackupTarget mounts left on the host permanently, defeating the purpose of DMS.

## Changes
- `kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-client-dmapi.conf.j2`: updated `db_url` to use `triliovault_db_details[1]` (workloadmgr) and `triliovault_wlm_database_password`.

## Test plan
- [ ] Deploy T4O on Kolla-Ansible OpenStack with this change
- [ ] Verify dmapi DMS client connects to `workloadmgr` database
- [ ] Verify BackupTarget mounts are cleaned up after operations
- [ ] Verify backups and restores continue to work correctly

Fixes: TVAULT-7361