### PR TITLE
TVAULT-7361: rhoso18 and canonical: use workloadmgr db for dmapi DMS client

### DIFF
--- a/juju-charms/charm-trilio-dm-api/src/config.yaml
+++ b/juju-charms/charm-trilio-dm-api/src/config.yaml
@@ -74,23 +74,3 @@ options:
     description: |
       Server timeout configuration in ms for haproxy, used in HA
       configurations.
-  wlm-db-host:
-    type: string
-    default: ""
-    description: MySQL hostname for the workloadmgr database (used by DMS client)
-  wlm-db-port:
-    type: int
-    default: 3306
-    description: MySQL port for the workloadmgr database
-  wlm-db-user:
-    type: string
-    default: "workloadmgr"
-    description: MySQL username for the workloadmgr database
-  wlm-db-password:
-    type: string
-    default: ""
-    description: MySQL password for the workloadmgr database
-  wlm-db-name:
-    type: string
-    default: "workloadmgr"
-    description: MySQL database name for workloadmgr

--- a/juju-charms/charm-trilio-dm-api/src/config.yaml
+++ b/juju-charms/charm-trilio-dm-api/src/config.yaml
@@ -74,3 +74,23 @@ options:
     description: |
       Server timeout configuration in ms for haproxy, used in HA
       configurations.
+  wlm-db-host:
+    type: string
+    default: ""
+    description: MySQL hostname for the workloadmgr database (used by DMS client)
+  wlm-db-port:
+    type: int
+    default: 3306
+    description: MySQL port for the workloadmgr database
+  wlm-db-user:
+    type: string
+    default: "workloadmgr"
+    description: MySQL username for the workloadmgr database
+  wlm-db-password:
+    type: string
+    default: ""
+    description: MySQL password for the workloadmgr database
+  wlm-db-name:
+    type: string
+    default: "workloadmgr"
+    description: MySQL database name for workloadmgr

--- a/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
+++ b/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
@@ -24,7 +24,7 @@ import charmhelpers.core.hookenv as hookenv
 DMAPI_DIR = "/etc/triliovault-datamover"
 DMAPI_CONF = os.path.join(DMAPI_DIR, "triliovault-datamover-api.conf")
 DMAPI_LOG_CONF = os.path.join(DMAPI_DIR, "datamover_api_logging.conf")
-DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf.d/dmapi.conf"
+DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf.d/triliovault-dms-client-dynamic.conf"
 
 plugins.trilio.make_trilio_handlers()
 

--- a/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
+++ b/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
@@ -24,6 +24,7 @@ import charmhelpers.core.hookenv as hookenv
 DMAPI_DIR = "/etc/triliovault-datamover"
 DMAPI_CONF = os.path.join(DMAPI_DIR, "triliovault-datamover-api.conf")
 DMAPI_LOG_CONF = os.path.join(DMAPI_DIR, "datamover_api_logging.conf")
+DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf"
 
 plugins.trilio.make_trilio_handlers()
 
@@ -45,6 +46,11 @@ class DmapiDBAdapter(adapters.DatabaseRelationAdapter):
     def dmapi_uri(self):
         """URI for dmapi DB"""
         return self.get_uri(prefix="dmapi")
+
+    @property
+    def wlm_uri(self):
+        """URI for workloadmgr DB (used by DMS client)"""
+        return self.get_uri(prefix="wlm")
 
 
 class DmapiAdapters(adapters.OpenStackAPIRelationAdapters):
@@ -88,7 +94,8 @@ class DmapiCharm(plugins.TrilioVaultCharm):
 
     # The restart map defines which services should be restarted when a given
     # file changes
-    restart_map = {DMAPI_CONF: services, DMAPI_LOG_CONF: services}
+    restart_map = {DMAPI_CONF: services, DMAPI_LOG_CONF: services,
+                   DMS_CLIENT_CONF: services}
 
     adapters_class = DmapiAdapters
 
@@ -209,6 +216,11 @@ class DmapiCharmQueens41(DmapiCharm):
                 "database": "dmapi",
                 "username": "dmapi",
                 "prefix": "dmapi",
+            },
+            {
+                "database": "workloadmgr",
+                "username": "workloadmgr",
+                "prefix": "wlm",
             },
         ]
 

--- a/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
+++ b/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
@@ -24,6 +24,7 @@ import charmhelpers.core.hookenv as hookenv
 DMAPI_DIR = "/etc/triliovault-datamover"
 DMAPI_CONF = os.path.join(DMAPI_DIR, "triliovault-datamover-api.conf")
 DMAPI_LOG_CONF = os.path.join(DMAPI_DIR, "datamover_api_logging.conf")
+DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf.d/dmapi.conf"
 
 plugins.trilio.make_trilio_handlers()
 
@@ -88,7 +89,8 @@ class DmapiCharm(plugins.TrilioVaultCharm):
 
     # The restart map defines which services should be restarted when a given
     # file changes
-    restart_map = {DMAPI_CONF: services, DMAPI_LOG_CONF: services}
+    restart_map = {DMAPI_CONF: services, DMAPI_LOG_CONF: services,
+                   DMS_CLIENT_CONF: services}
 
     adapters_class = DmapiAdapters
 
@@ -209,11 +211,6 @@ class DmapiCharmQueens41(DmapiCharm):
                 "database": "dmapi",
                 "username": "dmapi",
                 "prefix": "dmapi",
-            },
-            {
-                "database": "workloadmgr",
-                "username": "workloadmgr",
-                "prefix": "wlm",
             },
         ]
 

--- a/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
+++ b/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
@@ -24,7 +24,6 @@ import charmhelpers.core.hookenv as hookenv
 DMAPI_DIR = "/etc/triliovault-datamover"
 DMAPI_CONF = os.path.join(DMAPI_DIR, "triliovault-datamover-api.conf")
 DMAPI_LOG_CONF = os.path.join(DMAPI_DIR, "datamover_api_logging.conf")
-DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf"
 
 plugins.trilio.make_trilio_handlers()
 
@@ -46,11 +45,6 @@ class DmapiDBAdapter(adapters.DatabaseRelationAdapter):
     def dmapi_uri(self):
         """URI for dmapi DB"""
         return self.get_uri(prefix="dmapi")
-
-    @property
-    def wlm_uri(self):
-        """URI for workloadmgr DB (used by DMS client)"""
-        return self.get_uri(prefix="wlm")
 
 
 class DmapiAdapters(adapters.OpenStackAPIRelationAdapters):
@@ -94,8 +88,7 @@ class DmapiCharm(plugins.TrilioVaultCharm):
 
     # The restart map defines which services should be restarted when a given
     # file changes
-    restart_map = {DMAPI_CONF: services, DMAPI_LOG_CONF: services,
-                   DMS_CLIENT_CONF: services}
+    restart_map = {DMAPI_CONF: services, DMAPI_LOG_CONF: services}
 
     adapters_class = DmapiAdapters
 

--- a/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
+++ b/juju-charms/charm-trilio-dm-api/src/lib/charm/openstack/dmapi.py
@@ -24,7 +24,7 @@ import charmhelpers.core.hookenv as hookenv
 DMAPI_DIR = "/etc/triliovault-datamover"
 DMAPI_CONF = os.path.join(DMAPI_DIR, "triliovault-datamover-api.conf")
 DMAPI_LOG_CONF = os.path.join(DMAPI_DIR, "datamover_api_logging.conf")
-DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf.d/triliovault-dms-client-dynamic.conf"
+DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf"
 
 plugins.trilio.make_trilio_handlers()
 

--- a/juju-charms/charm-trilio-dm-api/src/metadata.yaml
+++ b/juju-charms/charm-trilio-dm-api/src/metadata.yaml
@@ -15,6 +15,9 @@ tags:
 provides:
   dm-api:
     interface: dm-api
+requires:
+  wlm-db:
+    interface: trilio-wlm-db
 series:
 - bionic
 - focal

--- a/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
+++ b/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
@@ -50,10 +50,12 @@ def render_config(*args):
         charm_class.render_with_interfaces(args)
         charm_class.assess_status()
 
-    # Render DMS client config for DMAPI
+    # Render DMS client config for DMAPI using WLM DB config options
     amqp = reactive.endpoint_from_flag('amqp.available')
-    db_ep = reactive.endpoint_from_flag('shared-db.available')
-    if amqp and db_ep:
+    charm_config = hookenv.config()
+    wlm_db_host = charm_config.get('wlm-db-host', '')
+    wlm_db_password = charm_config.get('wlm-db-password', '')
+    if amqp and wlm_db_host and wlm_db_password:
         amqp_username = amqp.username()
         amqp_password = amqp.password()
         amqp_host = amqp.private_address()
@@ -61,11 +63,10 @@ def render_config(*args):
         amqp_vhost = amqp.vhost()
         transport_url = f"rabbit://{amqp_username}:{amqp_password}@{amqp_host}:{amqp_port}/{amqp_vhost}"
 
-        db_password = db_ep.password(prefix='wlm')
-        db_user = 'workloadmgr'
-        db_host = '127.0.0.1'
-        db_name = 'workloadmgr'
-        db_url = f"mysql+pymysql://{db_user}:{db_password}@{db_host}/{db_name}"
+        wlm_db_user = charm_config.get('wlm-db-user', 'workloadmgr')
+        wlm_db_port = charm_config.get('wlm-db-port', 3306)
+        wlm_db_name = charm_config.get('wlm-db-name', 'workloadmgr')
+        db_url = f"mysql+pymysql://{wlm_db_user}:{wlm_db_password}@{wlm_db_host}:{wlm_db_port}/{wlm_db_name}"
 
         root_uid = pwd.getpwnam('root').pw_uid
         nova_gid = grp.getgrnam('nova').gr_gid
@@ -88,6 +89,8 @@ def render_config(*args):
         os.chmod(dms_client_conf_path, 0o640)
         os.chown(dms_client_conf_path, root_uid, nova_gid)
         hookenv.log("DMS client config rendered for dmapi.")
+    else:
+        hookenv.log("Skipping DMS client config: wlm-db-host or wlm-db-password not set.")
 
     reactive.set_state("config.rendered")
 
@@ -112,7 +115,7 @@ def cluster_connected(hacluster):
 def check_dmapi_db():
     db_ep = reactive.endpoint_from_flag('shared-db.available')
     if db_ep:
-        if db_ep.password(prefix='dmapi') and db_ep.password(prefix='wlm'):
+        if db_ep.password(prefix='dmapi'):
             reactive.set_state("dmapi-db.ready")
         else:
             with charm.provide_charm_instance() as instance:

--- a/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
+++ b/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
@@ -61,10 +61,10 @@ def render_config(*args):
         amqp_vhost = amqp.vhost()
         transport_url = f"rabbit://{amqp_username}:{amqp_password}@{amqp_host}:{amqp_port}/{amqp_vhost}"
 
-        db_password = db_ep.password(prefix='dmapi')
-        db_user = 'dmapi'
+        db_password = db_ep.password(prefix='wlm')
+        db_user = 'workloadmgr'
         db_host = '127.0.0.1'
-        db_name = 'dmapi'
+        db_name = 'workloadmgr'
         db_url = f"mysql+pymysql://{db_user}:{db_password}@{db_host}/{db_name}"
 
         root_uid = pwd.getpwnam('root').pw_uid
@@ -112,7 +112,7 @@ def cluster_connected(hacluster):
 def check_dmapi_db():
     db_ep = reactive.endpoint_from_flag('shared-db.available')
     if db_ep:
-        if db_ep.password(prefix='dmapi'):
+        if db_ep.password(prefix='dmapi') and db_ep.password(prefix='wlm'):
             reactive.set_state("dmapi-db.ready")
         else:
             with charm.provide_charm_instance() as instance:

--- a/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
+++ b/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
@@ -50,48 +50,6 @@ def render_config(*args):
         charm_class.render_with_interfaces(args)
         charm_class.assess_status()
 
-    # Render DMS client config for DMAPI using WLM DB config options
-    amqp = reactive.endpoint_from_flag('amqp.available')
-    charm_config = hookenv.config()
-    wlm_db_host = charm_config.get('wlm-db-host', '')
-    wlm_db_password = charm_config.get('wlm-db-password', '')
-    if amqp and wlm_db_host and wlm_db_password:
-        amqp_username = amqp.username()
-        amqp_password = amqp.password()
-        amqp_host = amqp.private_address()
-        amqp_port = amqp.ssl_port() or 5672
-        amqp_vhost = amqp.vhost()
-        transport_url = f"rabbit://{amqp_username}:{amqp_password}@{amqp_host}:{amqp_port}/{amqp_vhost}"
-
-        wlm_db_user = charm_config.get('wlm-db-user', 'workloadmgr')
-        wlm_db_port = charm_config.get('wlm-db-port', 3306)
-        wlm_db_name = charm_config.get('wlm-db-name', 'workloadmgr')
-        db_url = f"mysql+pymysql://{wlm_db_user}:{wlm_db_password}@{wlm_db_host}:{wlm_db_port}/{wlm_db_name}"
-
-        root_uid = pwd.getpwnam('root').pw_uid
-        nova_gid = grp.getgrnam('nova').gr_gid
-
-        dms_conf_dir = '/etc/triliovault-dms'
-        os.makedirs(dms_conf_dir, exist_ok=True)
-        os.makedirs(os.path.join(dms_conf_dir, 'client.conf.d'), exist_ok=True)
-        os.chown(dms_conf_dir, root_uid, nova_gid)
-
-        dms_client_context = {
-            'rabbitmq_url': transport_url,
-            'db_url': db_url,
-        }
-        dms_client_conf_path = os.path.join(dms_conf_dir, 'client.conf.d', 'dmapi.conf')
-        render(
-            source='triliovault-dms-client.conf',
-            target=dms_client_conf_path,
-            context=dms_client_context,
-        )
-        os.chmod(dms_client_conf_path, 0o640)
-        os.chown(dms_client_conf_path, root_uid, nova_gid)
-        hookenv.log("DMS client config rendered for dmapi.")
-    else:
-        hookenv.log("Skipping DMS client config: wlm-db-host or wlm-db-password not set.")
-
     reactive.set_state("config.rendered")
 
 
@@ -108,6 +66,57 @@ def cluster_connected(hacluster):
     with charm.provide_charm_instance() as charm_class:
         charm_class.configure_ha_resources(hacluster)
         charm_class.assess_status()
+
+
+@reactive.when('wlm-db.connected')
+@reactive.when('shared-db.available')
+@reactive.when('amqp.available')
+def render_dms_client_config(*args):
+    """Render DMS client config for dmapi using workloadmgr DB credentials from wlm-db relation."""
+    wlm_db_password = None
+    for rid in hookenv.relation_ids('wlm-db'):
+        for unit in hookenv.related_units(rid):
+            data = hookenv.relation_get(unit=unit, rid=rid)
+            wlm_db_password = data.get('workloadmgr_password', '')
+            if wlm_db_password:
+                break
+
+    if not wlm_db_password:
+        hookenv.log("wlm-db relation has no workloadmgr_password yet, skipping DMS client config.")
+        return
+
+    mysql_host = '127.0.0.1'
+    for rid in hookenv.relation_ids('shared-db'):
+        for unit in hookenv.related_units(rid):
+            data = hookenv.relation_get(unit=unit, rid=rid)
+            if data.get('db_host'):
+                mysql_host = data['db_host']
+                break
+
+    amqp = reactive.endpoint_from_flag('amqp.available')
+    transport_url = (
+        f"rabbit://{amqp.username()}:{amqp.password()}"
+        f"@{amqp.private_address()}:{amqp.ssl_port() or 5672}/{amqp.vhost()}"
+    )
+    db_url = f"mysql+pymysql://workloadmgr:{wlm_db_password}@{mysql_host}:3306/workloadmgr"
+
+    root_uid = pwd.getpwnam('root').pw_uid
+    nova_gid = grp.getgrnam('nova').gr_gid
+
+    dms_conf_dir = '/etc/triliovault-dms'
+    os.makedirs(dms_conf_dir, exist_ok=True)
+    os.makedirs(os.path.join(dms_conf_dir, 'client.conf.d'), exist_ok=True)
+    os.chown(dms_conf_dir, root_uid, nova_gid)
+
+    dms_client_conf_path = os.path.join(dms_conf_dir, 'client.conf.d', 'dmapi.conf')
+    render(
+        source='triliovault-dms-client.conf',
+        target=dms_client_conf_path,
+        context={'rabbitmq_url': transport_url, 'db_url': db_url},
+    )
+    os.chmod(dms_client_conf_path, 0o640)
+    os.chown(dms_client_conf_path, root_uid, nova_gid)
+    hookenv.log("DMS client config rendered for dmapi via wlm-db relation.")
 
 
 @reactive.when("shared-db.available")

--- a/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
+++ b/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
@@ -108,7 +108,7 @@ def render_dms_client_config(*args):
     os.makedirs(os.path.join(dms_conf_dir, 'client.conf.d'), exist_ok=True)
     os.chown(dms_conf_dir, root_uid, nova_gid)
 
-    dms_client_conf_path = os.path.join(dms_conf_dir, 'client.conf.d', 'dmapi.conf')
+    dms_client_conf_path = os.path.join(dms_conf_dir, 'client.conf.d', 'triliovault-dms-client-dynamic.conf')
     render(
         source='triliovault-dms-client.conf',
         target=dms_client_conf_path,

--- a/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
+++ b/juju-charms/charm-trilio-dm-api/src/reactive/dmapi_handlers.py
@@ -105,10 +105,9 @@ def render_dms_client_config(*args):
 
     dms_conf_dir = '/etc/triliovault-dms'
     os.makedirs(dms_conf_dir, exist_ok=True)
-    os.makedirs(os.path.join(dms_conf_dir, 'client.conf.d'), exist_ok=True)
     os.chown(dms_conf_dir, root_uid, nova_gid)
 
-    dms_client_conf_path = os.path.join(dms_conf_dir, 'client.conf.d', 'triliovault-dms-client-dynamic.conf')
+    dms_client_conf_path = os.path.join(dms_conf_dir, 'client.conf')
     render(
         source='triliovault-dms-client.conf',
         target=dms_client_conf_path,

--- a/juju-charms/charm-trilio-wlm/src/metadata.yaml
+++ b/juju-charms/charm-trilio-wlm/src/metadata.yaml
@@ -16,6 +16,9 @@ series:
 - bionic
 - focal
 - jammy
+provides:
+  wlm-db:
+    interface: trilio-wlm-db
 resources:
   license:
     type: file

--- a/juju-charms/charm-trilio-wlm/src/reactive/trilio_wlm_handlers.py
+++ b/juju-charms/charm-trilio-wlm/src/reactive/trilio_wlm_handlers.py
@@ -340,6 +340,17 @@ def register_endpoints_and_request_notification(identity_service):
         instance.assess_status()
 
 
+@reactive.when('wlm-db.connected')
+@reactive.when('shared-db.available')
+def publish_wlm_db_credentials(*args):
+    shared_db = reactive.RelationBase.from_state('shared-db.available')
+    if shared_db and shared_db.password():
+        for rid in hookenv.relation_ids('wlm-db'):
+            hookenv.relation_set(relation_id=rid,
+                                 workloadmgr_password=shared_db.password())
+        hookenv.log("Published workloadmgr DB password to wlm-db relation.")
+
+
 @reactive.when_any("config.changed.triliovault-pkg-source",
                    "config.changed.openstack-origin")
 def install_source_changed():

--- a/juju-charms/sample_overlay_bundles/tvo-6.0-2023.2-jammy-nfs-amazon-s3.yaml
+++ b/juju-charms/sample_overlay_bundles/tvo-6.0-2023.2-jammy-nfs-amazon-s3.yaml
@@ -124,3 +124,7 @@ relations:
   # # relation with DB server from the router
   - - mysql-innodb-cluster:db-router
     - trilio-wlm-mysql-router:db-router
+
+  # DMS client relation - dmapi uses workloadmgr DB credentials from wlm
+  - - trilio-wlm:wlm-db
+    - trilio-dm-api:wlm-db

--- a/juju-charms/sample_overlay_bundles/tvo-6.0-2023.2-jammy-nfs-ceph-s3-with-cert.yaml
+++ b/juju-charms/sample_overlay_bundles/tvo-6.0-2023.2-jammy-nfs-ceph-s3-with-cert.yaml
@@ -124,3 +124,7 @@ relations:
   # # relation with DB server from the router
   - - mysql-innodb-cluster:db-router
     - trilio-wlm-mysql-router:db-router
+
+  # DMS client relation - dmapi uses workloadmgr DB credentials from wlm
+  - - trilio-wlm:wlm-db
+    - trilio-dm-api:wlm-db

--- a/juju-charms/sample_overlay_bundles/tvo-6.2-2024.1-jammy.yaml
+++ b/juju-charms/sample_overlay_bundles/tvo-6.2-2024.1-jammy.yaml
@@ -107,3 +107,7 @@ relations:
     - vault:certificates
   - - mysql-innodb-cluster:db-router
     - trilio-wlm-mysql-router:db-router
+
+  # DMS client relation - dmapi uses workloadmgr DB credentials from wlm
+  - - trilio-wlm:wlm-db
+    - trilio-dm-api:wlm-db

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-datamover-api-init.sh.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-datamover-api-init.sh.tpl
@@ -39,7 +39,7 @@ tee > /tmp/pod-shared-triliovault-datamover-api/triliovault-dms-client-dynamic.c
 rabbitmq_url = rabbit://${DMAPI_RABBIT_USER}:${DMAPI_RABBIT_PASSWORD}@${DMAPI_RABBIT_HOST}:5671/${DMAPI_RABBIT_VHOST}?ssl=${RABBIT_SSL_ENABLED_NUM}
 
 # Database connection
-db_url = mysql+pymysql://${DMAPI_DATABASE_USER}:${DMAPI_DATABASE_PASSWORD}@${DMAPI_DATABASE_HOST}:${DMAPI_DATABASE_PORT}/${DMAPI_DATABASE_NAME}
+db_url = mysql+pymysql://${WLM_DATABASE_USER}:${WLM_DATABASE_PASSWORD}@${WLM_DATABASE_HOST}:${WLM_DATABASE_PORT}/${WLM_DATABASE_NAME}
 
 node_id = ${NODE_NAME}
 

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/datamover-api/deployment-datamover-api.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/templates/datamover-api/deployment-datamover-api.yaml
@@ -106,6 +106,19 @@ spec:
               value: "{{- .Values.database.common.port -}}"
             - name: DMAPI_DATABASE_NAME
               value: "{{- .Values.database.datamover_api.database -}}"
+            - name: WLM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: trilio-openstack-secret
+                  key: WlmDatabasePassword
+            - name: WLM_DATABASE_USER
+              value: "{{- .Values.database.wlm_api.user -}}"
+            - name: WLM_DATABASE_HOST
+              value: "{{- .Values.database.common.host -}}"
+            - name: WLM_DATABASE_PORT
+              value: "{{- .Values.database.common.port -}}"
+            - name: WLM_DATABASE_NAME
+              value: "{{- .Values.database.wlm_api.database -}}"
           terminationMessagePath: /var/log/termination-log
           volumeMounts:
             - name: triliovault-datamover-api-bin


### PR DESCRIPTION
## Summary
- RHOSO18: Pass WLM database env vars to datamover-api init container so the DMS client config can reference the workloadmgr database
- RHOSO18: Change dmapi DMS client db_url from DMAPI_DATABASE_* vars to WLM_DATABASE_* vars
- Canonical (charm-trilio-dm-api): Add workloadmgr database to dmapi get_database_setup, add wlm_uri adapter property, fix DMS client rendering to use workloadmgr credentials, require wlm password before marking DB ready

## Root Cause
The DMS client config for dmapi was pointing to the dmapi database. It should use the single workloadmgr database, same as WLM services.

## Test plan
- Deploy T4O on RHOSO18 and verify DMS client config inside dmapi pod has db_url pointing to workloadmgr database
- Deploy T4O on Canonical and verify DMS client config has db_url pointing to workloadmgr database
- Verify backups and restores continue to work after the fix

Fixes: TVAULT-7361