### PR TITLE
TVAULT-7374: create missing dirs before DMS container deploy on RHOSO18

### DIFF
--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/common.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/common.yml
@@ -8,7 +8,13 @@
     group: '42436'
     mode: '0755'
 
-- name: Ensure /var/lib/openstack/config/containers directory exists
+- name: Check if /var/lib/openstack/config/containers exists
+  become: true
+  ansible.builtin.stat:
+    path: /var/lib/openstack/config/containers
+  register: containers_dir
+
+- name: Create /var/lib/openstack/config/containers if not present
   become: true
   file:
     path: /var/lib/openstack/config/containers
@@ -16,3 +22,4 @@
     owner: root
     group: root
     mode: '0755'
+  when: not containers_dir.stat.exists

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/common.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/common.yml
@@ -1,0 +1,18 @@
+---
+- name: Ensure vault data directory exists
+  become: true
+  file:
+    path: "{{ vault_data_dir }}"
+    state: directory
+    owner: '42436'
+    group: '42436'
+    mode: '0755'
+
+- name: Ensure /var/lib/openstack/config/containers directory exists
+  become: true
+  file:
+    path: /var/lib/openstack/config/containers
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_datamover.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_datamover.yml
@@ -8,17 +8,14 @@
     mode: '0644'
 
 
-- name: Create Trilio datamover directories
+- name: Create Trilio datamover log directory
   become: true
   file:
-    path: "{{ item }}"
+    path: /var/log/containers/triliovault-datamover
     state: directory
     owner: '42436'
     group: '42436'
     mode: '0744'
-  with_items:
-    - "{{ vault_data_dir }}"
-    - /var/log/containers/triliovault-datamover
 
 - name: Create Trilio datamover configuration file
   become: true

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_dms.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_dms.yml
@@ -1,4 +1,22 @@
 ---
+- name: Ensure /var/lib/openstack/config/containers directory exists
+  become: true
+  file:
+    path: /var/lib/openstack/config/containers
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Ensure vault data directory exists
+  become: true
+  file:
+    path: "{{ vault_data_dir }}"
+    state: directory
+    owner: '42436'
+    group: '42436'
+    mode: '0755'
+
 - name: Ensure Trilio DMS directory exists
   become: true
   file:

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_dms.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/configure_dms.yml
@@ -1,22 +1,4 @@
 ---
-- name: Ensure /var/lib/openstack/config/containers directory exists
-  become: true
-  file:
-    path: /var/lib/openstack/config/containers
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-
-- name: Ensure vault data directory exists
-  become: true
-  file:
-    path: "{{ vault_data_dir }}"
-    state: directory
-    owner: '42436'
-    group: '42436'
-    mode: '0755'
-
 - name: Ensure Trilio DMS directory exists
   become: true
   file:

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/main.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/tasks/main.yml
@@ -34,6 +34,9 @@
     params: "nbds_max=128"
     state: "present"
 
+- name: Create common Trilio directories
+  ansible.builtin.include_tasks: common.yml
+
 - name: Configure and install triliovault DMS services
   ansible.builtin.include_tasks: configure_dms.yml
 


### PR DESCRIPTION
## Summary
- Pre-create `/var/lib/openstack/config/containers` before rendering the DMS container JSON, fixing the Ansible task failure: _Destination directory does not exist_
- Pre-create `{{ vault_data_dir }}` (`/var/lib/trilio/triliovault-mounts`) before deploying the DMS container, fixing the podman exit-125 error: _statfs: no such file or directory_

Both directories are created at the top of `configure_dms.yml` since DMS runs before the datamover tasks (`configure_datamover.yml` already creates `vault_data_dir` but runs after DMS).

## Test plan
- [ ] Deploy T4O 6.2 dataplane on a fresh RHOSO18 compute node and verify the `Configure and install triliovault DMS services` play succeeds end-to-end
- [ ] Confirm `triliovault-dms` container starts and stays running after deployment