### PR TITLE
TVAULT-7263: fail wlm-cloud-trust job when all retry attempts are exhausted

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-wlm-cloud-trust.sh.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-wlm-cloud-trust.sh.tpl
@@ -4,6 +4,7 @@ source /tmp/triliovault-cloudrc
 export OS_PROJECT_ID=$(openstack project show -f value -c id "${OS_PROJECT_NAME}")
 
 sleep 2m
+trust_created=false
 for attempt in {1..10};
 do
         echo -e "Attempting to create wlm-cloud admin trust, Attempt Number: $attempt"
@@ -16,6 +17,7 @@ do
             continue
         elif [ $status -eq 0 ]; then
             echo -e "wlm cloud admin trust created successfully"
+            trust_created=true
             break
         else
             echo -e "wlm cloud admin trust creation failed, re-trying"
@@ -23,3 +25,8 @@ do
             continue
         fi
 done
+
+if [ "$trust_created" != "true" ]; then
+    echo -e "wlm cloud admin trust creation failed after all attempts. Exiting."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- The wlm-cloud-trust shell script previously exited with code 0 even when all 10 retry attempts failed, causing the Kubernetes job to show Completed despite no trust being created
- Added a trust_created flag that is set only on successful trust creation; if the loop exhausts all attempts without setting it, the script now exits with code 1
- This allows the job backoffLimit 1000 retry policy to work correctly and makes failures visible in oc get pods

## Test plan
- Fresh install: verify job completes successfully and trust is created
- Upgrade scenario: verify job fails with exit code 1 if trust creation fails after all attempts, and pod shows Error status
- Verify oc logs job/job-triliovault-wlm-cloud-trust shows "wlm cloud admin trust creation failed after all attempts. Exiting." on failure

Fixes: TVAULT-7263
