### PR TITLE
kolla-ansible: use FQDN for DMS node_id instead of inventory_hostname

### DIFF
--- a/kolla-ansible/CLAUDE.md
+++ b/kolla-ansible/CLAUDE.md
@@ -107,3 +107,7 @@ Variables come from `defaults/main.yml` and injected globals. Use `{{ variable }
 2. Run `scripts/prepare_triliovault_role.py` to set up the role
 3. Run `generate-dynamic-values.sh` to produce runtime config
 4. `ansible-playbook -i triliovault_inventory.txt triliovault_site_<version>.yml`
+
+### Known Constraints
+- **`gather_facts: false` relies on kolla-ansible's fact cache**: `triliovault_site_<version>.yml` plays run with `gather_facts: false`, but templates still reference `ansible_*` facts (e.g. `ansible_fqdn`, `ansible_<iface>.ipv4.address`). This works because kolla-ansible's own deployment (a prerequisite before installing the T4O add-on) already gathered and cached facts for the same inventory. Don't assume facts are missing just because this playbook disables gathering.
+- **DMS `node_id` must be `ansible_fqdn`, not `inventory_hostname`**: `inventory_hostname` is just the name/alias used in the Ansible inventory file and is not guaranteed to be a resolvable hostname. DMS server `node_id` must match `OS-EXT-SRV-ATTR:host` from nova, and client-side `node_id` must be a real FQDN — use `ansible_fqdn` in these templates.

--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-client-dmapi.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-client-dmapi.conf.j2
@@ -2,7 +2,7 @@
 rabbitmq_url = rabbit://openstack:{{ om_rpc_password }}@{{ hostvars[groups[om_rpc_group][0]]['ansible_' + hostvars[groups[om_rpc_group][0]]['api_interface']]['ipv4']['address'] }}:{{ rabbitmq_port }}//
 
 db_url = mysql+pymysql://{{ triliovault_db_details[1].database_user }}:{{ triliovault_wlm_database_password }}@{{ triliovault_db_details[1].database_address }}/{{ triliovault_db_details[1].database_name }}
-node_id = {{ inventory_hostname }}
+node_id = {{ ansible_fqdn }}
 request_timeout = 60
 log_level = INFO
 log_file = /var/log/triliovault/trilio-dms-client.log

--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-client-wlm.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-client-wlm.conf.j2
@@ -2,7 +2,7 @@
 rabbitmq_url = rabbit://openstack:{{ om_rpc_password }}@{{ hostvars[groups[om_rpc_group][0]]['ansible_' + hostvars[groups[om_rpc_group][0]]['api_interface']]['ipv4']['address'] }}:{{ rabbitmq_port }}//
 
 db_url = mysql+pymysql://{{ triliovault_db_details[1].database_user }}:{{ triliovault_wlm_database_password }}@{{ triliovault_db_details[1].database_address }}/{{ triliovault_db_details[1].database_name }}
-node_id = {{ inventory_hostname }}
+node_id = {{ ansible_fqdn }}
 request_timeout = 60
 log_level = INFO
 log_file = /var/log/triliovault/trilio-dms-client.log

--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-server-ctlplane.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-server-ctlplane.conf.j2
@@ -6,7 +6,7 @@ rabbitmq_queue_type = quorum
 {% endif %}
 
 # Node identifier — must match OS-EXT-SRV-ATTR:host from nova (the nova-compute host value)
-node_id = {{ inventory_hostname }}
+node_id = {{ ansible_fqdn }}
 
 # Keystone auth URL for Barbican token validation
 auth_url = {{ keystone_internal_url }}

--- a/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-server-dataplane.conf.j2
+++ b/kolla-ansible/ansible/roles/triliovault/templates/triliovault-dms-server-dataplane.conf.j2
@@ -6,7 +6,7 @@ rabbitmq_queue_type = quorum
 {% endif %}
 
 # Node identifier — must match OS-EXT-SRV-ATTR:host from nova (the nova-compute host value)
-node_id = {{ inventory_hostname }}
+node_id = {{ ansible_fqdn }}
 
 # Keystone auth URL for Barbican token validation
 auth_url = {{ keystone_internal_url }}


### PR DESCRIPTION
## Summary
- DMS client/server conf templates in kolla-ansible used `inventory_hostname`, which is whatever short/logical name is set in the Ansible inventory, not a resolvable FQDN.
- Switched `node_id` in all four templates (`triliovault-dms-server-dataplane.conf.j2`, `triliovault-dms-server-ctlplane.conf.j2`, `triliovault-dms-client-wlm.conf.j2`, `triliovault-dms-client-dmapi.conf.j2`) to use `ansible_fqdn` instead.

## Test plan
- [ ] Render templates against a kolla-ansible inventory where `inventory_hostname` differs from the host's FQDN and confirm `node_id` now resolves to the FQDN.
- [ ] Verify DMS client/server still start and register correctly with the new `node_id` value.

Jira: TVAULT-7407