### PR TITLE
TVAULT-7422: sync T4O rabbitmq client conf with OpenStack oslo_messaging_rabbit settings

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
@@ -35,7 +35,9 @@ auth_uri = {{ .Values.keystone.common.auth_uri }}
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
-amqp_durable_queues = {{ if .Values.rabbitmq.cluster.rabbit_quorum_queue }}true{{ else }}false{{ end }}
+rabbit_transient_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_transient_quorum_queue }}
+amqp_durable_queues = {{ .Values.rabbitmq.cluster.amqp_durable_queues }}
+heartbeat_in_pthread = false
 
 [oslo_messaging_notifications]
 driver = {{ .Values.rabbitmq.common.driver }}

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_datamover_api_conf.tpl
@@ -34,9 +34,9 @@ auth_uri = {{ .Values.keystone.common.auth_uri }}
 [oslo_messaging_rabbit]
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
-rabbit_transient_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_transient_quorum_queue }}
-amqp_durable_queues = {{ .Values.rabbitmq.cluster.amqp_durable_queues }}
+rabbit_quorum_queue = {{ .Values.rabbitmq.common.rabbit_quorum_queue }}
+rabbit_transient_quorum_queue = {{ .Values.rabbitmq.common.rabbit_transient_quorum_queue }}
+amqp_durable_queues = {{ .Values.rabbitmq.common.amqp_durable_queues }}
 heartbeat_in_pthread = false
 
 [oslo_messaging_notifications]

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_dms_server_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_dms_server_conf.tpl
@@ -7,7 +7,7 @@
 # Keystone auth URL
 auth_url = {{ .Values.keystone.common.auth_url }}
 
-{{- if .Values.rabbitmq.cluster.rabbit_quorum_queue }}
+{{- if .Values.rabbitmq.common.rabbit_quorum_queue }}
 # Use quorum queue type for RabbitMQ
 rabbitmq_queue_type = quorum
 {{- end }}

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
@@ -68,5 +68,7 @@ helper_command = sudo /usr/bin/workloadmgr-rootwrap /etc/triliovault-wlm/rootwra
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
-amqp_durable_queues = {{ if .Values.rabbitmq.cluster.rabbit_quorum_queue }}true{{ else }}false{{ end }}
+rabbit_transient_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_transient_quorum_queue }}
+amqp_durable_queues = {{ .Values.rabbitmq.cluster.amqp_durable_queues }}
+heartbeat_in_pthread = false
 

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/conf/_triliovault_wlm_conf.tpl
@@ -67,8 +67,8 @@ helper_command = sudo /usr/bin/workloadmgr-rootwrap /etc/triliovault-wlm/rootwra
 [oslo_messaging_rabbit]
 ssl = {{ .Values.rabbitmq.common.ssl }}
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-rabbit_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_quorum_queue }}
-rabbit_transient_quorum_queue = {{ .Values.rabbitmq.cluster.rabbit_transient_quorum_queue }}
-amqp_durable_queues = {{ .Values.rabbitmq.cluster.amqp_durable_queues }}
+rabbit_quorum_queue = {{ .Values.rabbitmq.common.rabbit_quorum_queue }}
+rabbit_transient_quorum_queue = {{ .Values.rabbitmq.common.rabbit_transient_quorum_queue }}
+amqp_durable_queues = {{ .Values.rabbitmq.common.amqp_durable_queues }}
 heartbeat_in_pthread = false
 

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
@@ -88,6 +88,9 @@ rabbitmq:
     driver: "messagingv2"
     ssl: true
     namespace: "trilio-openstack"
+    rabbit_quorum_queue: true
+    rabbit_transient_quorum_queue: true
+    amqp_durable_queues: true
   operator:
     api_version: "operators.coreos.com/v1"
     operator_name: "rabbitmq-cluster-operator"
@@ -99,9 +102,6 @@ rabbitmq:
   cluster:
     api_version: "rabbitmq.com/v1beta1"
     replicas: 3
-    rabbit_quorum_queue: true
-    rabbit_transient_quorum_queue: true
-    amqp_durable_queues: true
     image: "rabbitmq:3.13.7-management"
     resources:
       requests:

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/values.yaml
@@ -99,7 +99,9 @@ rabbitmq:
   cluster:
     api_version: "rabbitmq.com/v1beta1"
     replicas: 3
-    rabbit_quorum_queue: false
+    rabbit_quorum_queue: true
+    rabbit_transient_quorum_queue: true
+    amqp_durable_queues: true
     image: "rabbitmq:3.13.7-management"
     resources:
       requests:

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/set_operator_inputs.py
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/set_operator_inputs.py
@@ -119,6 +119,37 @@ def fetch_and_extract_cluster_domain():
         print(f"Failed to fetch Glance endpoint: {e}")
         return None, None
 
+# Function to fetch OpenStack's Nova rabbitmq queue type (Quorum vs Mirrored/Classic)
+def get_openstack_rabbit_quorum_state():
+    try:
+        print("Checking OpenStack Nova rabbitmq queue type...")
+        result = subprocess.run(
+            ["oc", "get", "transporturl", "nova-api-transport", "-n", "openstack", "-o", "jsonpath={.status.queueType}"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        queue_type = result.stdout.strip()
+        if not queue_type:
+            print("nova-api-transport queueType not found. Leaving rabbit_quorum_queue as configured.")
+            return None
+        print(f"OpenStack Nova rabbitmq queueType: '{queue_type}'")
+        return queue_type.lower() == "quorum"
+    except subprocess.CalledProcessError:
+        print("Failed to fetch nova-api-transport queueType. Leaving rabbit_quorum_queue as configured.")
+        return None
+
+# Function to sync T4O's rabbitmq client params (rabbit_quorum_queue, amqp_durable_queues) with OpenStack's
+def update_rabbit_params():
+    quorum_enabled = get_openstack_rabbit_quorum_state()
+    if quorum_enabled is None:
+        return
+    if "spec" in yaml_data and "rabbitmq" in yaml_data["spec"] and "cluster" in yaml_data["spec"]["rabbitmq"]:
+        yaml_data["spec"]["rabbitmq"]["cluster"]["rabbit_quorum_queue"] = quorum_enabled
+        yaml_data["spec"]["rabbitmq"]["cluster"]["rabbit_transient_quorum_queue"] = quorum_enabled
+        yaml_data["spec"]["rabbitmq"]["cluster"]["amqp_durable_queues"] = quorum_enabled
+        print(f"- Updated rabbitmq.cluster.rabbit_quorum_queue, rabbit_transient_quorum_queue and amqp_durable_queues to: {quorum_enabled}")
+
 # Function to update keystone endpoints for trilio services
 def update_keystone_endpoints():
     glance_url, cluster_domain = fetch_and_extract_cluster_domain()
@@ -203,7 +234,7 @@ if keystone_url:
 
 
 update_keystone_endpoints()
-print("Calling rabbit params method")
+update_rabbit_params()
 with open(yaml_file, "w") as file:
     yaml_parser.dump(yaml_data, file)
 

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/set_operator_inputs.py
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/set_operator_inputs.py
@@ -144,11 +144,11 @@ def update_rabbit_params():
     quorum_enabled = get_openstack_rabbit_quorum_state()
     if quorum_enabled is None:
         return
-    if "spec" in yaml_data and "rabbitmq" in yaml_data["spec"] and "cluster" in yaml_data["spec"]["rabbitmq"]:
-        yaml_data["spec"]["rabbitmq"]["cluster"]["rabbit_quorum_queue"] = quorum_enabled
-        yaml_data["spec"]["rabbitmq"]["cluster"]["rabbit_transient_quorum_queue"] = quorum_enabled
-        yaml_data["spec"]["rabbitmq"]["cluster"]["amqp_durable_queues"] = quorum_enabled
-        print(f"- Updated rabbitmq.cluster.rabbit_quorum_queue, rabbit_transient_quorum_queue and amqp_durable_queues to: {quorum_enabled}")
+    if "spec" in yaml_data and "rabbitmq" in yaml_data["spec"] and "common" in yaml_data["spec"]["rabbitmq"]:
+        yaml_data["spec"]["rabbitmq"]["common"]["rabbit_quorum_queue"] = quorum_enabled
+        yaml_data["spec"]["rabbitmq"]["common"]["rabbit_transient_quorum_queue"] = quorum_enabled
+        yaml_data["spec"]["rabbitmq"]["common"]["amqp_durable_queues"] = quorum_enabled
+        print(f"- Updated rabbitmq.common.rabbit_quorum_queue, rabbit_transient_quorum_queue and amqp_durable_queues to: {quorum_enabled}")
 
 # Function to update keystone endpoints for trilio services
 def update_keystone_endpoints():

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
@@ -127,12 +127,12 @@ spec:
       driver: "messagingv2"
       ssl: true
       namespace: "trilio-openstack"
-    cluster:
-      api_version: "rabbitmq.com/v1beta1"
-      replicas: 3
       rabbit_quorum_queue: true
       rabbit_transient_quorum_queue: true
       amqp_durable_queues: true
+    cluster:
+      api_version: "rabbitmq.com/v1beta1"
+      replicas: 3
       resources:
         requests:
           cpu: "1"
@@ -161,9 +161,7 @@ spec:
           ssl_options.fail_if_no_peer_cert = false
           ssl_options.depth = 1
 
-          # Quorum queue optimizations (Raft-based), Uncomment following three parameters if your rabbitm image supports quorum queue. It should have version >= 3.13
-          #raft.wal_max_size_bytes = 134217728
-          #raft.segment_max_entries = 32768
+          # Manual Change: default_queue_type parameter is removed starting RHOSO18 FR5 (18.0.17) release, since quorum queues become the default without it. Only uncomment on pre-FR5 releases (< 18.0.17) if you want to enable quorum queues.
           #default_queue_type = quorum
 
           # Memory and disk management (adjusted for 2Gi memory)

--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
@@ -130,7 +130,9 @@ spec:
     cluster:
       api_version: "rabbitmq.com/v1beta1"
       replicas: 3
-      rabbit_quorum_queue: false
+      rabbit_quorum_queue: true
+      rabbit_transient_quorum_queue: true
+      amqp_durable_queues: true
       resources:
         requests:
           cpu: "1"

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/defaults/main.yml
@@ -14,7 +14,9 @@ cinder_backend_ceph: true
 libvirt_images_rbd_ceph_conf: "/etc/ceph/ceph.conf"
 ceph_cinder_user: "cinder"
 oslomsg_rpc_use_ssl: true
-rabbit_quorum_queue: false
+rabbit_quorum_queue: true
+rabbit_transient_quorum_queue: true
+amqp_durable_queues: true
 cinder_backend_power_flex: false
 ## Do we need this parameter? Check datamover conf.
 cinder_http_retries: "10"

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/ansible-roles/trilio-datamover/templates/triliovault_datamover_conf.j2
@@ -19,8 +19,10 @@ keyring_ext = .keyring
 
 [oslo_messaging_rabbit]
 rabbit_quorum_queue = {{ rabbit_quorum_queue }}
+rabbit_transient_quorum_queue = {{ rabbit_transient_quorum_queue }}
 ssl = {{ rabbit_ssl }}
-amqp_durable_queues = {{ 'true' if rabbit_quorum_queue | bool else 'false' }}
+amqp_durable_queues = {{ amqp_durable_queues }}
+heartbeat_in_pthread = false
 ssl_ca_file = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [dmapi_database]

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/cm-trilio-datamover.yaml
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/cm-trilio-datamover.yaml
@@ -8,7 +8,9 @@ data:
     rabbit_host: "rabbitmq.openstack.svc"
     rabbit_port: "5671"
     rabbit_ssl: true
-    rabbit_quorum_queue: false
+    rabbit_quorum_queue: true
+    rabbit_transient_quorum_queue: true
+    amqp_durable_queues: true
     database_host: "openstack.openstack.svc"
     database_port: "3306"
     keystone_auth_url: "https://keystone.openstack.svc:5000/v3"

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/set_data_plane_inputs.py
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/set_data_plane_inputs.py
@@ -28,9 +28,9 @@ with open(SECRET_FILE) as f:
 # Extract data
 rabbit_host = data["spec"]["rabbitmq"]["common"].get("host", "")
 rabbit_ssl = data["spec"]["rabbitmq"]["common"].get("ssl", True)
-rabbit_quorum_queue = data["spec"]["rabbitmq"]["common"].get("rabbit_quorum_queue", False)
-rabbit_transient_quorum_queue = data["spec"]["rabbitmq"]["common"].get("rabbit_transient_quorum_queue", False)
-amqp_durable_queues = data["spec"]["rabbitmq"]["common"].get("amqp_durable_queues", False)
+rabbit_quorum_queue = data["spec"]["rabbitmq"]["common"].get("rabbit_quorum_queue", True)
+rabbit_transient_quorum_queue = data["spec"]["rabbitmq"]["common"].get("rabbit_transient_quorum_queue", True)
+amqp_durable_queues = data["spec"]["rabbitmq"]["common"].get("amqp_durable_queues", True)
 database_host = data["spec"]["database"]["common"].get("host", "")
 database_port = data["spec"]["database"]["common"].get("port", "3306")
 keystone_auth_url = data["spec"]["keystone"]["common"].get("auth_url", "")

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/set_data_plane_inputs.py
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/set_data_plane_inputs.py
@@ -28,9 +28,9 @@ with open(SECRET_FILE) as f:
 # Extract data
 rabbit_host = data["spec"]["rabbitmq"]["common"].get("host", "")
 rabbit_ssl = data["spec"]["rabbitmq"]["common"].get("ssl", True)
-rabbit_quorum_queue = data["spec"]["rabbitmq"]["cluster"].get("rabbit_quorum_queue", False)
-rabbit_transient_quorum_queue = data["spec"]["rabbitmq"]["cluster"].get("rabbit_transient_quorum_queue", False)
-amqp_durable_queues = data["spec"]["rabbitmq"]["cluster"].get("amqp_durable_queues", False)
+rabbit_quorum_queue = data["spec"]["rabbitmq"]["common"].get("rabbit_quorum_queue", False)
+rabbit_transient_quorum_queue = data["spec"]["rabbitmq"]["common"].get("rabbit_transient_quorum_queue", False)
+amqp_durable_queues = data["spec"]["rabbitmq"]["common"].get("amqp_durable_queues", False)
 database_host = data["spec"]["database"]["common"].get("host", "")
 database_port = data["spec"]["database"]["common"].get("port", "3306")
 keystone_auth_url = data["spec"]["keystone"]["common"].get("auth_url", "")

--- a/redhat-director-scripts/rhosp18/dataplane-scripts/set_data_plane_inputs.py
+++ b/redhat-director-scripts/rhosp18/dataplane-scripts/set_data_plane_inputs.py
@@ -29,6 +29,8 @@ with open(SECRET_FILE) as f:
 rabbit_host = data["spec"]["rabbitmq"]["common"].get("host", "")
 rabbit_ssl = data["spec"]["rabbitmq"]["common"].get("ssl", True)
 rabbit_quorum_queue = data["spec"]["rabbitmq"]["cluster"].get("rabbit_quorum_queue", False)
+rabbit_transient_quorum_queue = data["spec"]["rabbitmq"]["cluster"].get("rabbit_transient_quorum_queue", False)
+amqp_durable_queues = data["spec"]["rabbitmq"]["cluster"].get("amqp_durable_queues", False)
 database_host = data["spec"]["database"]["common"].get("host", "")
 database_port = data["spec"]["database"]["common"].get("port", "3306")
 keystone_auth_url = data["spec"]["keystone"]["common"].get("auth_url", "")
@@ -47,6 +49,10 @@ with open(CM_FILE, "r") as f:
             updated_lines.append(f'    rabbit_ssl: {str(rabbit_ssl).lower()}\n')
         elif "rabbit_quorum_queue:" in line:
             updated_lines.append(f'    rabbit_quorum_queue: {str(rabbit_quorum_queue).lower()}\n')
+        elif "rabbit_transient_quorum_queue:" in line:
+            updated_lines.append(f'    rabbit_transient_quorum_queue: {str(rabbit_transient_quorum_queue).lower()}\n')
+        elif "amqp_durable_queues:" in line:
+            updated_lines.append(f'    amqp_durable_queues: {str(amqp_durable_queues).lower()}\n')
         elif "database_host:" in line:
             updated_lines.append(f'    database_host: "{database_host}"\n')
         elif "database_port:" in line:


### PR DESCRIPTION
## Summary
- `set_operator_inputs.py` now reads OpenStack's live RabbitMQ queue type (via the `nova-api-transport` TransportURL's `status.queueType`) and syncs `rabbit_quorum_queue`, `rabbit_transient_quorum_queue`, and `amqp_durable_queues` into `tvo-operator-inputs.yaml` to match, instead of leaving them as static/guessed values.
- `amqp_durable_queues` is decoupled from being inline-derived off `rabbit_quorum_queue` in the ctlplane conf templates (wlm, dmapi) and the dataplane datamover conf template; all four `[oslo_messaging_rabbit]` params (`rabbit_quorum_queue`, `rabbit_transient_quorum_queue`, `amqp_durable_queues`, `heartbeat_in_pthread`) are now rendered explicitly, matching what OpenStack's own Nova service renders.
- `heartbeat_in_pthread` is hardcoded to `false` (static oslo.log-hang workaround default; never varies with queue type, confirmed against two live RHOSO18 clusters on either side of the 18.0.17/FR5 boundary).
- Threaded the new `rabbit_transient_quorum_queue` / `amqp_durable_queues` params through the dataplane chain (`defaults/main.yml` -> `triliovault_datamover_conf.j2` -> `set_data_plane_inputs.py` -> `cm-trilio-datamover.yaml`) the same way `rabbit_quorum_queue` already flows.
- DMS server/client conf templates and `_triliovault_dms_server_conf.tpl`/`triliovault_dms_conf.j2` are untouched -- they use a custom non-oslo.messaging protocol with no durable/heartbeat concept.

## Test plan
- [ ] Deploy T4O control plane against a RHOSO18 cluster with Nova on classic/mirrored queues; confirm `tvo-operator-inputs.yaml` and rendered wlm/dmapi confs show `rabbit_quorum_queue=false`, `rabbit_transient_quorum_queue=false`, `amqp_durable_queues=false`.
- [ ] Deploy against a RHOSO18 FR5+ (>=18.0.17) cluster with Nova on quorum queues; confirm all three render as `true`.
- [ ] Run `set_data_plane_inputs.py` and confirm `cm-trilio-datamover.yaml` and the rendered `triliovault-datamover.conf` on a compute node pick up the same values.
- [ ] Confirm datamover/dmapi/wlm services connect to the Trilio RabbitMQ cluster without AMQP errors after this change.