### PR TITLE
TVAULT-7422: remove unsupported default_queue_type from tvo-operator-inputs.yaml

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/tvo-operator-inputs.yaml
@@ -161,9 +161,6 @@ spec:
           ssl_options.fail_if_no_peer_cert = false
           ssl_options.depth = 1
 
-          # Manual Change: default_queue_type parameter is removed starting RHOSO18 FR5 (18.0.17) release, since quorum queues become the default without it. Only uncomment on pre-FR5 releases (< 18.0.17) if you want to enable quorum queues.
-          #default_queue_type = quorum
-
           # Memory and disk management (adjusted for 2Gi memory)
           vm_memory_high_watermark.relative = 0.6
           vm_memory_high_watermark_paging_ratio = 0.75


### PR DESCRIPTION
## Summary
- Follow-up to #1504. Removes the commented `#default_queue_type = quorum` line (and its explanatory comment) from T4O's own RabbitMQ cluster `additional_config` block in `tvo-operator-inputs.yaml`.
- Confirmed via Red Hat errata (RHEA-2024:5245) that RHOSO18 ships `rabbitmq-server-3.9.10`, which predates the RabbitMQ 3.13.3/3.13.4 engine version that introduced `default_queue_type` as a valid global `rabbitmq.conf` directive. Uncommenting it on RHOSO18 fails RabbitMQ cluster deployment with a schema validation error (confirmed against a live cluster).
- Not needed anyway: T4O's client services (wlm, dmapi, datamover) already declare quorum vs classic explicitly per queue via `rabbit_quorum_queue` in their `[oslo_messaging_rabbit]` conf sections (from #1504), so this server-side default was never load-bearing for the actual fix.

## Test plan
- [ ] Deploy T4O control plane on RHOSO18 and confirm the RabbitMQ cluster comes up cleanly (no schema validation errors) with the updated `additional_config` block.
- [ ] Confirm quorum vs classic queue behavior is still correctly driven by `rabbit_quorum_queue`/`amqp_durable_queues` in the client confs, unaffected by this removal.