### PR TITLE
TVAULT-7263: Fix set -e killing wlm-cloud-trust retry loop on first failure

### DIFF
--- a/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-wlm-cloud-trust.sh.tpl
+++ b/redhat-director-scripts/rhosp18/ctlplane-scripts/operator/tvo-operator/helm-charts/tvo-chart/scripts/_triliovault-wlm-cloud-trust.sh.tpl
@@ -8,8 +8,11 @@ trust_created=false
 for attempt in {1..10};
 do
         echo -e "Attempting to create wlm-cloud admin trust, Attempt Number: $attempt"
-        command_output=$(workloadmgr trust-create --is_cloud_trust True admin --insecure 2>&1)
-        status=$?
+        if command_output=$(workloadmgr trust-create --is_cloud_trust True admin --insecure 2>&1); then
+            status=0
+        else
+            status=$?
+        fi
         echo "Command output: $command_output"
         if echo "$command_output" | grep -q "unavailable"; then
             echo -e "wlm cloud admin trust create command failed due to wlm service unavailability. Will re-try after 30 seconds"


### PR DESCRIPTION
## Summary
- The `wlm-cloud-trust` job's retry loop used a bare assignment (`command_output=$(workloadmgr trust-create ... 2>&1)`) with `set -e` active. When the command failed, the failed assignment itself tripped `set -e` and killed the script immediately — before `status=$?` or any of the retry/echo logic ran.
- This meant the script's own 10-attempt/30s retry loop never actually executed past attempt 1 within a single process; recovery relied entirely on the Kubernetes Job's `OnFailure` restarts (backoffLimit: 1000), producing many pod restarts with no error ever logged (every crash showed only `Attempt Number: 1`).
- Reported on TVAULT-7263 during a `6.1.9-1 -> 6.2.1` upgrade, where `wlm-api` takes longer to become ready than a fresh deployment, so `trust-create` failed repeatedly before the job finally succeeded after ~19 restarts.
- Fix: wrap the command substitution in an `if/else` so a failure is captured into `status` without triggering `set -e`, letting the existing retry loop run its full 10 attempts (with proper logging) within one pod lifetime instead of relying on pod-level restarts.

## Test plan
- [ ] Verified locally that `set -e` no longer kills the loop on a failing command substitution (see reasoning/tests in TVAULT-7263 comments)
- [ ] Deploy RHOSO18 control plane during a `6.1.x -> 6.2.1` upgrade and confirm `wlm-cloud-trust` job logs show retry attempts incrementing (2, 3, ...) with failure messages, without requiring excessive pod restarts
- [ ] Confirm job still fails the pod (exit 1) after exhausting all 10 attempts if `wlm-api`/keystone never become available