### PR TITLE
TVAULT-7404: Add Sunbeam Canonical OpenStack support (native Juju charms)

### DIFF
--- a/sunbeam-canonical/README.md
+++ b/sunbeam-canonical/README.md
@@ -14,10 +14,10 @@ TrilioVault maps onto this cleanly:
 | WorkloadManager (wlm-api, wlm-workloads, wlm-cron, wlm-scheduler) | `openstack` (k8s) | `trilio-wlm-k8s` |
 | DataMover API (dmapi) | `openstack` (k8s) | `trilio-dm-api-k8s` |
 | Dynamic Mount Service — control plane | `openstack` (k8s) | `trilio-dms-k8s` |
-| DataMover + DMS (compute side) | `openstack-machines` (machine) | `trilio-data-mover` |
+| DataMover + DMS (compute side) | `openstack-machines` (machine) | `trilio-data-mover-sunbeam` |
 | Horizon Plugin | `openstack` (k8s) | OCI image attach to `horizon-k8s` |
 
-`trilio-data-mover` is a **Juju subordinate charm** targeting `openstack-hypervisor`.
+`trilio-data-mover-sunbeam` is a **Juju subordinate charm** targeting `openstack-hypervisor`.
 It installs both `tvault-contego` (DataMover) and `trilio-dms-server` (compute-side DMS) on every compute node.
 When a new compute node joins via `sunbeam cluster join`, Juju automatically deploys a DataMover unit on it — no manual operator action required.
 
@@ -105,7 +105,7 @@ Horizon reloads automatically — no restart required.
 | `trilio-wlm-k8s` | `charms/trilio-wlm-k8s/` | k8s, Pebble |
 | `trilio-dm-api-k8s` | `charms/trilio-dm-api-k8s/` | k8s, Pebble |
 | `trilio-dms-k8s` | `charms/trilio-dms-k8s/` | k8s, Pebble — control plane DMS server |
-| `trilio-data-mover` | `charms/trilio-data-mover/` | machine subordinate, runs DataMover + compute DMS |
+| `trilio-data-mover-sunbeam` | `charms/trilio-data-mover/` | machine subordinate, runs DataMover + compute DMS |
 
 ## OCI Images
 

--- a/sunbeam-canonical/build/build_publish.sh
+++ b/sunbeam-canonical/build/build_publish.sh
@@ -55,6 +55,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+[[ "$BUILD_ONLY" == "true" && "$PUBLISH_ONLY" == "true" ]] && die "--build-only and --publish-only are mutually exclusive"
+
 [[ ${#SELECTED_CHARMS[@]} -eq 0 ]] && SELECTED_CHARMS=("${ALL_CHARMS[@]}")
 
 for charm in "${SELECTED_CHARMS[@]}"; do
@@ -95,7 +97,7 @@ for charm in "${SELECTED_CHARMS[@]}"; do
     [[ -n "$charm_file" ]] || die "No .charm file found for '$charm' in $charm_dir. Run without --publish-only to build first."
 
     log "[$charm] Uploading $charm_file ..."
-    upload_out=$(charmcraft upload "$charm_file" --format json)
+    upload_out=$(charmcraft --format json upload "$charm_file")
     revision=$(python3 -c "import sys, json; print(json.load(sys.stdin)['revision'])" <<< "$upload_out")
     log "[$charm] Uploaded as revision $revision"
 

--- a/sunbeam-canonical/build/build_publish.sh
+++ b/sunbeam-canonical/build/build_publish.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# build_publish.sh — Build and publish TrilioVault Sunbeam charms to Charmhub
+#
+# Packs each charm with charmcraft, uploads to Charmhub, and releases to the
+# specified channel. Requires charmcraft installed and logged in:
+#   sudo snap install charmcraft --classic
+#   charmcraft login
+#
+# Usage (run from any directory):
+#   bash sunbeam-canonical/build/build_publish.sh [OPTIONS]
+#
+# Options:
+#   --channel <CHANNEL>   Charmhub channel to release to (default: 2024.1/edge)
+#   --build-only          Pack charms but skip upload and release
+#   --publish-only        Upload/release pre-built .charm files, skip pack
+#   --charm <NAME>        Target one charm only (repeatable); default: all four
+#   -h, --help            Show this help
+#
+# Charm names on Charmhub:
+#   trilio-wlm-k8s
+#   trilio-dm-api-k8s
+#   trilio-dms-k8s
+#   trilio-data-mover-sunbeam
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHARMS_DIR="$(dirname "$SCRIPT_DIR")/charms"
+
+CHANNEL="2024.1/edge"
+BUILD_ONLY=false
+PUBLISH_ONLY=false
+SELECTED_CHARMS=()
+
+# Charmhub name → source directory under charms/
+declare -A CHARM_DIR_MAP=(
+    [trilio-wlm-k8s]="trilio-wlm-k8s"
+    [trilio-dm-api-k8s]="trilio-dm-api-k8s"
+    [trilio-dms-k8s]="trilio-dms-k8s"
+    [trilio-data-mover-sunbeam]="trilio-data-mover"
+)
+ALL_CHARMS=(trilio-wlm-k8s trilio-dm-api-k8s trilio-dms-k8s trilio-data-mover-sunbeam)
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --channel)       CHANNEL="$2";            shift 2 ;;
+        --build-only)    BUILD_ONLY=true;          shift   ;;
+        --publish-only)  PUBLISH_ONLY=true;        shift   ;;
+        --charm)         SELECTED_CHARMS+=("$2");  shift 2 ;;
+        -h|--help)       grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) die "Unknown option: $1" ;;
+    esac
+done
+
+[[ ${#SELECTED_CHARMS[@]} -eq 0 ]] && SELECTED_CHARMS=("${ALL_CHARMS[@]}")
+
+for charm in "${SELECTED_CHARMS[@]}"; do
+    [[ -v CHARM_DIR_MAP[$charm] ]] || die "Unknown charm '$charm'. Valid: ${ALL_CHARMS[*]}"
+done
+
+log "Charms       : ${SELECTED_CHARMS[*]}"
+log "Channel      : $CHANNEL"
+log "Build-only   : $BUILD_ONLY"
+log "Publish-only : $PUBLISH_ONLY"
+echo
+
+# ---------------------------------------------------------------------------
+# Step 1 — Pack
+# ---------------------------------------------------------------------------
+if [[ "$PUBLISH_ONLY" != "true" ]]; then
+    for charm in "${SELECTED_CHARMS[@]}"; do
+        charm_dir="$CHARMS_DIR/${CHARM_DIR_MAP[$charm]}"
+        [[ -d "$charm_dir" ]] || die "Charm directory not found: $charm_dir"
+
+        log "[$charm] Packing ..."
+        (cd "$charm_dir" && charmcraft pack --verbose)
+        log "[$charm] Pack complete"
+    done
+fi
+
+[[ "$BUILD_ONLY" == "true" ]] && { log "Build-only mode — done."; exit 0; }
+
+# ---------------------------------------------------------------------------
+# Step 2 — Upload and release
+# ---------------------------------------------------------------------------
+for charm in "${SELECTED_CHARMS[@]}"; do
+    charm_dir="$CHARMS_DIR/${CHARM_DIR_MAP[$charm]}"
+
+    # charmcraft pack writes the .charm file into the charm directory.
+    # Filename pattern: <charm-name>_ubuntu-22.04-amd64.charm
+    charm_file=$(ls "$charm_dir"/${charm}_*.charm 2>/dev/null | sort -V | tail -1)
+    [[ -n "$charm_file" ]] || die "No .charm file found for '$charm' in $charm_dir. Run without --publish-only to build first."
+
+    log "[$charm] Uploading $charm_file ..."
+    upload_out=$(charmcraft upload "$charm_file" --format json)
+    revision=$(python3 -c "import sys, json; print(json.load(sys.stdin)['revision'])" <<< "$upload_out")
+    log "[$charm] Uploaded as revision $revision"
+
+    log "[$charm] Releasing revision $revision to $CHANNEL ..."
+    charmcraft release "$charm" --revision "$revision" --channel "$CHANNEL"
+    log "[$charm] Released to $CHANNEL"
+done
+
+echo
+log "All charms published to channel: $CHANNEL"

--- a/sunbeam-canonical/charms/trilio-data-mover/charmcraft.yaml
+++ b/sunbeam-canonical/charms/trilio-data-mover/charmcraft.yaml
@@ -1,4 +1,4 @@
-name: trilio-data-mover
+name: trilio-data-mover-sunbeam
 type: charm
 title: TrilioVault DataMover (Sunbeam)
 summary: TrilioVault DataMover subordinate charm for Sunbeam Canonical OpenStack

--- a/sunbeam-canonical/charms/trilio-data-mover/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover/src/charm.py
@@ -224,9 +224,9 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         identity = self._identity_data()
 
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://{amqp.get('username', 'dms')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
-            f"/{amqp.get('vhost', 'dmapi')}"
+            f"/{amqp.get('vhost', 'dms')}"
         )
         auth_url = (
             f"{identity.get('credentials_protocol', 'http')}://"

--- a/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 CONTAINER = "trilio-dm-api"
 CONFIG_PATH = "/etc/triliovault-datamover/dmapi.conf"
 DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf"
-S3VAULTFUSE_CONF = "/etc/triliovault-dms/s3vaultfuse-global.conf"
 LOG_DIR = "/var/log/triliovault-datamover"
 DMAPI_PORT = 8784
 

--- a/sunbeam-canonical/charms/trilio-dms-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-dms-k8s/src/charm.py
@@ -98,9 +98,9 @@ class TrilioDmsK8sCharm(ops.CharmBase):
         identity = self._identity_data()
 
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://{amqp.get('username', 'dms')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
-            f"/{amqp.get('vhost', 'dmapi')}"
+            f"/{amqp.get('vhost', 'dms')}"
         )
         auth_url = (
             f"{identity.get('service_protocol', 'http')}://"

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -45,11 +45,16 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             self.framework.observe(
                 getattr(self.on, f"{rel}_relation_changed"), self._configure
             )
+        self.framework.observe(self.on.wlm_service_relation_joined, self._on_wlm_service_joined)
 
     # --- event handlers ---
 
     def _on_pebble_ready(self, event):
         self._configure(event)
+
+    def _on_wlm_service_joined(self, event):
+        if self.unit.is_leader():
+            self._publish_wlm_service_data()
 
     def _configure(self, event):
         container = self.unit.get_container(CONTAINER)
@@ -248,16 +253,17 @@ class TrilioWlmK8sCharm(ops.CharmBase):
                 "startup": "enabled",
             },
         }
-        # wlm-cron must run as a single instance cluster-wide — restrict to leader unit.
+        # wlm-cron must run as a single instance cluster-wide.
         # Multiple wlm-cron instances cause duplicate scheduled job execution
         # and corrupt workload state in the database.
-        if self.unit.is_leader():
-            services["wlm-cron"] = {
-                "override": "replace",
-                "summary": "WLM Cron (leader-only singleton)",
-                "command": cmd_base.format("wlm-cron"),
-                "startup": "enabled",
-            }
+        # Always include the service definition so Pebble can disable it on non-leaders;
+        # omitting it entirely leaves a previously-enabled layer in force.
+        services["wlm-cron"] = {
+            "override": "replace",
+            "summary": "WLM Cron (leader-only singleton)",
+            "command": cmd_base.format("wlm-cron"),
+            "startup": "enabled" if self.unit.is_leader() else "disabled",
+        }
         return ops.pebble.Layer({"summary": "TrilioVault WLM services", "services": services})
 
     def _update_pebble_layer(self, container):

--- a/sunbeam-canonical/trilio-ctlplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-ctlplane-bundle.yaml
@@ -18,7 +18,7 @@ applications:
 
   trilio-wlm-k8s:
     charm: trilio-wlm-k8s
-    channel: stable
+    channel: 2024.1/stable
     scale: 1
     trust: true
     options:
@@ -27,7 +27,7 @@ applications:
 
   trilio-dm-api-k8s:
     charm: trilio-dm-api-k8s
-    channel: stable
+    channel: 2024.1/stable
     scale: 1
     trust: true
     options:
@@ -36,7 +36,7 @@ applications:
 
   trilio-dms-k8s:
     charm: trilio-dms-k8s
-    channel: stable
+    channel: 2024.1/stable
     scale: 1
     trust: true
     options:

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -21,7 +21,7 @@ bundle: machine
 applications:
 
   trilio-data-mover:
-    charm: trilio-data-mover
+    charm: trilio-data-mover-sunbeam
     channel: stable
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.trilio.io jammy main"

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -22,7 +22,7 @@ applications:
 
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
-    channel: stable
+    channel: 2024.1/stable
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.trilio.io jammy main"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"

--- a/sunbeam-canonical/upgrade.sh
+++ b/sunbeam-canonical/upgrade.sh
@@ -41,20 +41,22 @@ fi
 log() { echo "[$(date '+%H:%M:%S')] $*"; }
 
 # --- Step 1: Upgrade control plane charms ---
-log "Upgrading trilio-wlm-k8s to version $TRILIO_VERSION in model $CTLPLANE_MODEL"
+log "Upgrading control plane charms to version $TRILIO_VERSION in model $CTLPLANE_MODEL"
 juju switch "$CTLPLANE_MODEL"
-juju refresh trilio-wlm-k8s  --channel stable
-juju refresh trilio-dm-api-k8s --channel stable
+juju refresh trilio-wlm-k8s    --channel 2024.1/stable
+juju refresh trilio-dm-api-k8s --channel 2024.1/stable
+juju refresh trilio-dms-k8s    --channel 2024.1/stable
 
 log "Waiting for control plane to become active post-upgrade..."
-juju wait-for application trilio-wlm-k8s  --query='status=="active"' --timeout=10m
+juju wait-for application trilio-wlm-k8s    --query='status=="active"' --timeout=10m
 juju wait-for application trilio-dm-api-k8s --query='status=="active"' --timeout=10m
+juju wait-for application trilio-dms-k8s    --query='status=="active"' --timeout=10m
 
 # --- Step 2: Upgrade data plane ---
 log "Upgrading trilio-data-mover to version $TRILIO_VERSION in model $DATAPLANE_MODEL"
 juju switch "$DATAPLANE_MODEL"
 juju config trilio-data-mover trilio-version="$TRILIO_VERSION"
-juju refresh trilio-data-mover --channel stable
+juju refresh trilio-data-mover --channel 2024.1/stable
 
 log "Waiting for data plane to become active post-upgrade..."
 juju wait-for application trilio-data-mover --query='status=="active"' --timeout=10m


### PR DESCRIPTION
## Summary

- Adds first-time T4O support for **Sunbeam Canonical OpenStack** (Caracal / 2024.1) using native Juju charms (ops + Pebble), replacing the earlier Helm/Ansible approach
- Four new charms under `sunbeam-canonical/charms/`:
  - `trilio-wlm-k8s` — k8s charm running wlm-api, wlm-workloads, wlm-scheduler, wlm-cron (leader-only singleton) via Pebble
  - `trilio-dm-api-k8s` — k8s charm running dmapi via Pebble
  - `trilio-dms-k8s` — k8s charm running the control-plane DMS server via Pebble
  - `trilio-data-mover` (Charmhub: `trilio-data-mover-sunbeam`) — machine subordinate to `openstack-hypervisor`, runs DataMover + compute-side DMS server
- Deployment scripts: `install.sh`, `upgrade.sh`, bundle YAMLs, and `build/build_publish.sh` for Charmhub releases
- All four charms implement DMS client config (`/etc/triliovault-dms/client.conf`) and/or `s3vaultfuse-global.conf` per the DevOps DMS spec
- Backup targets not managed in 6.2 — cloud admins configure via T4O CLI/UI post-deployment

## Key design decisions

- Control plane charms deploy into the `openstack` k8s model; data plane subordinate deploys into `openstack-machines` machine model — two separate `juju deploy` calls wrapped by `bash install.sh`
- Cross-model SAAS: data plane consumes rabbitmq + keystone-credentials offered from the `openstack` model
- `node_id` uses `socket.gethostname()` (same approach as Sunbeam nova charms — no nova.conf dependency)
- Charm naming follows Sunbeam convention: `<service>-k8s` for k8s charms (matches `nova-k8s`, `cinder-k8s` etc.)
- Channel convention: `2024.1/stable` (not bare `stable` which resolves to `latest/stable`)

## Test plan

- [ ] Deploy Sunbeam Caracal environment and run `bash install.sh`
- [ ] Verify all four charms reach `active/idle` in their respective models
- [ ] Confirm wlm-cron runs only on WLM leader unit
- [ ] Confirm DMS client.conf and s3vaultfuse-global.conf written correctly on each node
- [ ] Run `bash upgrade.sh --trilio-version <next>` and verify all charms refresh including `trilio-dms-k8s`
- [ ] Run `bash build/build_publish.sh --build-only` and confirm `.charm` files produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)