### PR TITLE
TVAULT-7404: Fix Sunbeam charm bugs — compute DMS, RabbitMQ URLs, CA cert, and Keystone registration

### DIFF
--- a/sunbeam-canonical/CLAUDE.md
+++ b/sunbeam-canonical/CLAUDE.md
@@ -103,6 +103,15 @@ Fix: prefix the command with `setsid` — e.g. `["setsid", "workloadmgr", ...]`.
 
 This issue does NOT appear with `kubectl exec -- bash -c '...'` because that path starts processes without a controlling terminal in the container, whereas Pebble (as container PID 1) inherits one from the kubelet.
 
+### api-paste.ini — charm must overwrite package file
+The `api-paste.ini` shipped by the `workloadmgr` deb package contains legacy `%SERVICE_TENANT_NAME%`, `%SERVICE_USER%`, `%SERVICE_PASSWORD%` placeholders. Python's `configparser` raises `InterpolationSyntaxError` on `%` that aren't valid `%(var)s` interpolation, crashing wlm-api on startup. Fix: the WLM charm writes a clean `WLM_API_PASTE` constant directly to `/etc/triliovault-wlm/api-paste.ini` in `_write_config()`, overwriting the package-shipped file. The removed `[filter:authtoken]` password fields are NOT needed — keystonemiddleware reads auth from `[keystone_authtoken]` in the main conf.
+
+### sql_connection in [DEFAULT] — not [database]
+WLM reads the DB URL from `sql_connection` in the `[DEFAULT]` section, **not** from `connection` in `[database]`. All other deployment methods (RHOSP17, RHOSO18, Kolla) all use `sql_connection` in `[DEFAULT]`. The `[database]` section with `connection` key is a newer Oslo convention that WLM does not use. Both must be present: `[DEFAULT].sql_connection` for WLM's own DB access, and `[alembic].sqlalchemy.url` for alembic migrations.
+
+### RabbitMQ user/vhost for WLM: `wlm` (not `workloadmgr`)
+The RabbitMQ user and vhost for WLM are named `wlm`/`wlm` — created by the previous Juju charm version (charm-trilio-wlm from juju-charms/). The Sunbeam charm must request `username=wlm`, `vhost=wlm` in the amqp relation databag. Using `workloadmgr` for username/vhost causes `(403) ACCESS_REFUSED` from RabbitMQ because that user was never created. The database name (MySQL) and binary name remain `workloadmgr`.
+
 ### wlm-cron singleton constraint
 Only ONE instance of `wlm-cron` must run cluster-wide. The charm enforces this by setting `startup: disabled` for wlm-cron on non-leader units. Multiple wlm-cron instances cause duplicate scheduled job execution and corrupt workload state in the database.
 

--- a/sunbeam-canonical/CLAUDE.md
+++ b/sunbeam-canonical/CLAUDE.md
@@ -96,6 +96,13 @@ Additionally:
 - `log_config_append = <path>` points to the per-service Python logging conf pushed by the charm
 - Log formatter classes: `workloadmgr.openstack.common.log.UTCFormatter`, `dmapi.common.log.UTCFormatter`, `contego.common.log.UTCFormatter`, `s3fuse.log.UTCFormatter`
 
+### workloadmgr CLI in Pebble exec — setsid required
+When the WLM charm runs `workloadmgr` via `container.exec()` (Pebble), the process inherits Pebble's controlling terminal (the container's `/dev/console`). `workloadmgr`'s cliff/cmd2 layer opens `/dev/tty` and calls `curses.cbreak()`, which fails on the container console with "cbreak() returned ERR".
+
+Fix: prefix the command with `setsid` — e.g. `["setsid", "workloadmgr", ...]`. `setsid` creates a new session with no controlling terminal, so `/dev/tty` open fails with ENXIO and cmd2 skips curses init gracefully.
+
+This issue does NOT appear with `kubectl exec -- bash -c '...'` because that path starts processes without a controlling terminal in the container, whereas Pebble (as container PID 1) inherits one from the kubelet.
+
 ### wlm-cron singleton constraint
 Only ONE instance of `wlm-cron` must run cluster-wide. The charm enforces this by setting `startup: disabled` for wlm-cron on non-leader units. Multiple wlm-cron instances cause duplicate scheduled job execution and corrupt workload state in the database.
 

--- a/sunbeam-canonical/CLAUDE.md
+++ b/sunbeam-canonical/CLAUDE.md
@@ -176,28 +176,36 @@ Our Trilio k8s charms use **plain `ops`** (not `ops_sunbeam`) to avoid the frame
 | DMAPI | 8784 | `datamover` | `dmapi` |
 | DMS server | (no HTTP; RabbitMQ only) | — | — |
 
-WLM endpoint URL format (public/internal): `https://IP:443/<model>-<app>/v1/$(tenant_id)s` (via Traefik when ingress is configured), falls back to `http://<app>:8781/v1/$(tenant_id)s`
-DMAPI endpoint URL format (public/internal): `https://IP:443/<model>-<app>/v2` (via Traefik when ingress is configured), falls back to `http://<app>:8784/v2`
+WLM endpoint URL format (public/internal): `https://IP/openstack-trilio-wlm/v1/$(tenant_id)s` (via Traefik), falls back to `http://trilio-wlm-k8s:8781/v1/$(tenant_id)s`
+DMAPI endpoint URL format (public/internal): `https://IP/openstack-trilio-dm-api/v2` (via Traefik), falls back to `http://trilio-dm-api-k8s:8784/v2`
 Admin URL is always the plain k8s service address (Traefik does not route admin traffic).
 
+The ingress `name` sent to Traefik is a **fixed constant** (`trilio-wlm`, `trilio-dm-api`) — NOT `self.app.name`. This drops the `-k8s` suffix to match OpenStack's endpoint naming convention (nova, glance, etc. all omit the `-k8s` charm suffix). The Traefik path becomes `/openstack-<name>`.
+
 ### Traefik ingress databag format (requirer side)
-Traefik v2 expects the **requirer** to write a single `data` key with a JSON-encoded dict — NOT individual top-level keys. Port must be an integer (not a string).
+Traefik v2 `IngressPerAppRequirer` expects **individual top-level keys** — NOT a single nested `data` JSON blob. Port must be a JSON-encoded integer. Additionally, **every unit** must write `host` and `ip` to its own unit databag or Traefik's `is_ready` check returns False and it wipes the ingress.
+
 ```python
-rel.data[self.app]["data"] = json.dumps({
-    "model": self.model.name,
-    "name": self.app.name,
-    "port": PORT,           # integer
-    "scheme": "http",
-    "strip-prefix": False,  # boolean
-    "redirect-https": False,
-})
+# App databag — leader only
+if self.unit.is_leader():
+    rel.data[self.app]["model"] = json.dumps(self.model.name)   # e.g. '"openstack"'
+    rel.data[self.app]["name"]  = json.dumps(WLM_INGRESS_NAME)  # '"trilio-wlm"'
+    rel.data[self.app]["port"]  = json.dumps(WLM_PORT)          # '8781'
+
+# Unit databag — every unit (not just leader)
+binding = self.model.get_binding(rel)
+ip = str(binding.network.bind_address) if binding and binding.network.bind_address else None
+rel.data[self.unit]["host"] = json.dumps(socket.getfqdn())
+if ip:
+    rel.data[self.unit]["ip"] = json.dumps(ip)
 ```
-Writing individual keys (model="..", name="..", port="8781") causes Traefik to log "invalid databag contents: expecting json" and block.
+
+Writing a nested `data` key (e.g. `rel.data[self.app]["data"] = json.dumps({...})`) causes Traefik to silently ignore the requirer as not ready and wipe its own ingress response.
 
 ### Traefik ingress URL pattern (provider response)
 Traefik writes the routed URL into the ingress relation app databag as:
 ```
-rel.data[rel.app]["ingress"] = '{"url": "https://IP:443/model-appname"}'
+rel.data[rel.app]["ingress"] = '{"url": "https://IP/openstack-trilio-wlm"}'
 ```
 Read it with: `json.loads(rel.data[rel.app].get("ingress", "{}")).get("url")`.
 Charms must observe `ingress_*_relation_changed` (not just `_joined`) to re-register Keystone endpoints once Traefik has written this URL — Traefik writes the URL asynchronously after the requirer joins.

--- a/sunbeam-canonical/CLAUDE.md
+++ b/sunbeam-canonical/CLAUDE.md
@@ -105,8 +105,21 @@ Only ONE instance of `wlm-cron` must run cluster-wide. The charm enforces this b
 
 ### DMS systemd units (data plane)
 Neither `python3-trilio-dms` nor `tvault-contego` packages ship systemd unit files (both were designed for kolla containers). The `trilio-data-mover` charm writes both units to `/lib/systemd/system/` during install:
-- `triliovault-dms.service` — runs `trilio-dms-server` as nova user
-- `tvault-contego.service` — runs tvault-contego with nova.conf from the openstack-hypervisor snap at `/var/snap/openstack-hypervisor/current/etc/nova/nova.conf`
+- `triliovault-dms.service` — runs `trilio-dms-server` as nova user, with `PYTHONPATH=/snap/openstack-hypervisor/current/usr/lib/python3/dist-packages` so it can import nova/kombu from the snap
+- `triliovault-datamover.service` — runs tvault-contego as nova user with the same PYTHONPATH, using `--config-file=/etc/triliovault-datamover/nova.conf` (our patched copy) and `--config-file=/etc/triliovault-datamover/triliovault-datamover.conf`
+
+### nova.conf and CA cert handling (data plane)
+The `openstack-hypervisor` snap's nova.conf is at `/var/snap/openstack-hypervisor/common/etc/nova/nova.conf` (root:root 640 — unreadable by the nova user). The charm copies it to `/etc/triliovault-datamover/nova.conf` (root:nova 640).
+
+**Only one line is patched in the copy**: the `cafile=` line in `[keystone_authtoken]` (and any other section) that references a snap-internal path (`/var/snap/openstack-hypervisor/.../receive-ca-bundle.pem`, also root:root 640). It is rewritten to `/etc/triliovault-datamover/ca-bundle.pem`.
+
+The CA cert at that path comes from the **`receive-ca-cert` Juju relation** — NOT copied from the snap. `_write_ca_cert()` reads the CA from the relation databag and writes it to:
+1. `/etc/triliovault-datamover/ca-bundle.pem` (root:nova 640) — for tvault-contego's direct use via `cafile=`
+2. `/usr/local/share/ca-certificates/trilio-ca.crt` + `update-ca-certificates` — system trust store for all other tools
+
+**Ordering in `_configure()`**: `_write_ca_cert()` must run before `_sync_nova_conf()` so the CA file exists before nova.conf references it.
+
+If the `receive-ca-cert` relation has no data yet, the `cafile=` line is stripped entirely so keystoneauth1 falls back to the world-readable system CA trust store.
 
 ### DMS client conf (data plane only)
 `/etc/triliovault-dms/client.conf` is written by the `trilio-data-mover` charm when `wlm-db-url` config is set. It contains WLM DB URL, same RabbitMQ credentials as DMS server, and `node_id = socket.getfqdn()`. Control plane charms (WLM, DMAPI) do not get a DMS client conf in the current implementation.

--- a/sunbeam-canonical/README.md
+++ b/sunbeam-canonical/README.md
@@ -112,7 +112,8 @@ Horizon reloads automatically — no restart required.
 To build OCI images or Juju charms, the build machine must have Docker and charmcraft installed.
 A setup script is provided to prepare any Ubuntu machine in one step:
 
-**Supported OS**: Ubuntu 22.04 LTS (Jammy) or later (24.04 LTS Noble also supported).
+**Supported OS**: Ubuntu 22.04 LTS (Jammy) or 24.04 LTS (Noble).
+Canonical's own sunbeam-charms CI targets Ubuntu 24.04 Noble; both versions work for Trilio builds.
 
 ```bash
 # Run from the repository root — idempotent, safe to re-run
@@ -120,8 +121,8 @@ bash sunbeam-canonical/build/setup_build_machine.sh
 ```
 
 What the script installs:
-- Docker CE (from the official Docker APT repository)
-- `charmcraft` snap (for building Juju charms)
+- Docker CE (from the official Docker APT repository) — required for OCI image builds
+- `charmcraft` snap (`latest/stable` channel) — required for Juju charm builds
 - Base dependencies: `git`, `curl`, `python3`, `snapd`
 
 After the script completes:

--- a/sunbeam-canonical/README.md
+++ b/sunbeam-canonical/README.md
@@ -98,6 +98,33 @@ juju attach-resource horizon-k8s \
 
 Horizon reloads automatically — no restart required.
 
+### 4. Cloud Admin Trust
+
+TrilioVault needs a trust relationship between the WLM service user and the Cloud Admin
+so it can impersonate tenants during backup and restore operations.
+Run this once after the WLM charm reaches active status:
+
+```bash
+juju switch openstack
+juju run trilio-wlm-k8s/leader create-cloud-admin-trust \
+  password=<cloud-admin-password>
+```
+
+Optional params (defaults work for standard Sunbeam deployments):
+- `user-domain-name` (default: `admin_domain`)
+- `project-name` (default: `admin`)
+- `project-domain-name` (default: `admin_domain`)
+
+### 5. Apply License
+
+Attach the TrilioVault license file and apply it:
+
+```bash
+juju switch openstack
+juju attach-resource trilio-wlm-k8s license=<path-to-license-file>
+juju run trilio-wlm-k8s/leader create-license
+```
+
 ## Charm Source Code
 
 | Charm | Location | Notes |

--- a/sunbeam-canonical/README.md
+++ b/sunbeam-canonical/README.md
@@ -107,9 +107,34 @@ Horizon reloads automatically — no restart required.
 | `trilio-dms-k8s` | `charms/trilio-dms-k8s/` | k8s, Pebble — control plane DMS server |
 | `trilio-data-mover-sunbeam` | `charms/trilio-data-mover-sunbeam/` | machine subordinate, runs DataMover + compute DMS |
 
+## Build Prerequisites
+
+To build OCI images or Juju charms, the build machine must have Docker and charmcraft installed.
+A setup script is provided to prepare any Ubuntu machine in one step:
+
+**Supported OS**: Ubuntu 22.04 LTS (Jammy) or later (24.04 LTS Noble also supported).
+
+```bash
+# Run from the repository root — idempotent, safe to re-run
+bash sunbeam-canonical/build/setup_build_machine.sh
+```
+
+What the script installs:
+- Docker CE (from the official Docker APT repository)
+- `charmcraft` snap (for building Juju charms)
+- Base dependencies: `git`, `curl`, `python3`, `snapd`
+
+After the script completes:
+1. Re-login or run `newgrp docker` so the `docker` group takes effect
+2. `docker login` with your Docker Hub credentials
+3. Export charmcraft credentials: `export CHARMCRAFT_AUTH=$(cat creds.txt)`
+   (generate `creds.txt` with `charmcraft login --export creds.txt` on a machine with a browser)
+
+---
+
 ## OCI Images
 
-Dockerfiles are in `../docker/sunbeam-canonical/`:
+Dockerfiles are in `docker/`:
 
 | Image | Dockerfile | Used by |
 |-------|-----------|---------|

--- a/sunbeam-canonical/build/setup_build_machine.sh
+++ b/sunbeam-canonical/build/setup_build_machine.sh
@@ -3,7 +3,8 @@
 #                          Sunbeam Docker images and Juju charms.
 #
 # Idempotent: safe to re-run; already-installed tools are skipped.
-# Tested on Ubuntu 22.04 and 24.04.
+# Supported OS: Ubuntu 22.04 LTS (Jammy) or 24.04 LTS (Noble).
+# Canonical sunbeam-charms CI targets Ubuntu 24.04; both versions work.
 #
 # What this installs:
 #   - Docker CE            (for building OCI images with devops-build-publish.sh)
@@ -84,7 +85,7 @@ if snap list charmcraft &>/dev/null 2>&1; then
     skip "charmcraft already installed (version $CURRENT)"
 else
     log "Installing charmcraft snap ..."
-    sudo snap install charmcraft --classic
+    sudo snap install charmcraft --classic --channel latest/stable
     log "charmcraft installed: $(charmcraft --version)"
 fi
 

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -340,14 +340,38 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         return None
 
     def _identity_data(self):
-        """keystone-credentials interface: provider app databag."""
+        """keystone-credentials interface: provider app databag.
+
+        The keystone-credentials interface returns auth-host, auth-port,
+        auth-protocol, and a Juju secret under 'credentials' that holds
+        the actual username/password. Returns a normalized dict with
+        credentials_host, credentials_password, etc. so callers don't
+        need to know the wire format.
+        """
         rel = self.model.get_relation("identity-credentials")
         if not rel:
             return None
         d = rel.data[rel.app]
-        if d.get("credentials_host") and d.get("credentials_password"):
-            return d
-        return None
+        host = d.get("auth-host")
+        secret_id = d.get("credentials")
+        if not host or not secret_id:
+            return None
+        try:
+            secret = self.model.get_secret(id=secret_id)
+            creds = secret.get_content()
+        except Exception:
+            return None
+        if not creds.get("password"):
+            return None
+        return {
+            "credentials_host": host,
+            "credentials_port": d.get("auth-port", "5000"),
+            "credentials_protocol": d.get("auth-protocol", "http"),
+            "credentials_username": creds.get("username", "datamover"),
+            "credentials_password": creds["password"],
+            "credentials_project": d.get("project-name", "services"),
+            "internal_endpoint": d.get("internal-endpoint", ""),
+        }
 
     def _get_ca_cert(self):
         """Return concatenated CA certs from receive-ca-cert relation, or None."""
@@ -517,9 +541,14 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
             f"/{amqp.get('vhost', 'dmapi')}"
         )
+        # Use the HTTPS internal endpoint if keystone published one via traefik;
+        # fall back to plain-http k8s service address for fresh deploys.
         auth_url = (
-            f"{identity.get('credentials_protocol', 'http')}://"
-            f"{identity['credentials_host']}:{identity.get('credentials_port', '5000')}/v3"
+            identity.get("internal_endpoint")
+            or (
+                f"{identity.get('credentials_protocol', 'http')}://"
+                f"{identity['credentials_host']}:{identity.get('credentials_port', '5000')}/v3"
+            )
         )
 
         cfg = configparser.ConfigParser()

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -78,6 +78,10 @@ StartLimitBurst=3
 User=nova
 Group=nova
 Type=simple
+# tvault-contego imports from nova (e.g. nova.exception). On Sunbeam compute nodes
+# nova runs inside the openstack-hypervisor snap; add the snap's dist-packages to
+# PYTHONPATH so tvault-contego can import nova and other OpenStack libraries.
+Environment="PYTHONPATH=/snap/openstack-hypervisor/current/usr/lib/python3/dist-packages"
 ExecStart=/usr/bin/python3 /usr/bin/tvault-contego \
   --config-file=/var/snap/openstack-hypervisor/common/etc/nova/nova.conf \
   --config-file=/etc/triliovault-datamover/triliovault-datamover.conf

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -532,9 +532,9 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         amqp = self._amqp_data()
 
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://datamover:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
-            f"/{amqp.get('vhost', 'dmapi')}"
+            f"/datamover"
         )
 
         cfg = configparser.ConfigParser()
@@ -584,9 +584,9 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         identity = self._identity_data()
 
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://datamover:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
-            f"/{amqp.get('vhost', 'dmapi')}"
+            f"/datamover"
         )
         # Use the HTTPS internal endpoint if keystone published one via traefik;
         # fall back to plain-http k8s service address for fresh deploys.
@@ -634,9 +634,9 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
 
         amqp = self._amqp_data()
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://datamover:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
-            f"/{amqp.get('vhost', 'dmapi')}"
+            f"/datamover"
         )
 
         cfg = configparser.ConfigParser()

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -21,8 +21,9 @@ and handle NFS / S3 mount operations on their respective hosts.
 
 import configparser
 import hashlib
-import re
 import io
+import json
+import re
 import logging
 import os
 import pathlib
@@ -294,10 +295,16 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         self._configure(event)
 
     def _on_amqp_relation_joined(self, event):
-        """Write rabbitmq requirer credentials so rabbitmq-k8s provisions the user/vhost."""
+        """Write rabbitmq requirer credentials so rabbitmq-k8s provisions the user/vhost.
+
+        external_connectivity=true tells rabbitmq-k8s to return the loadbalancer IP
+        (e.g. 172.26.x.x) instead of the k8s-internal DNS name, which is not
+        resolvable from compute nodes outside the k8s cluster.
+        """
         if self.unit.is_leader():
             event.relation.data[self.app]["username"] = "datamover"
             event.relation.data[self.app]["vhost"] = "datamover"
+            event.relation.data[self.app]["external_connectivity"] = json.dumps(True)
 
     def _on_identity_credentials_relation_joined(self, event):
         """Write keystone requirer username so keystone-k8s provisions datamover credentials."""
@@ -316,6 +323,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         if amqp_rel:
             amqp_rel.data[self.app]["username"] = "datamover"
             amqp_rel.data[self.app]["vhost"] = "datamover"
+            amqp_rel.data[self.app]["external_connectivity"] = json.dumps(True)
         identity_rel = self.model.get_relation("identity-credentials")
         if identity_rel:
             identity_rel.data[self.app]["username"] = "datamover"

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -21,6 +21,7 @@ and handle NFS / S3 mount operations on their respective hosts.
 
 import configparser
 import hashlib
+import re
 import io
 import logging
 import os
@@ -38,10 +39,15 @@ DATAMOVER_SERVICE = "triliovault-datamover"
 DMS_SERVICE = "triliovault-dms"
 DM_CONFIG_PATH = "/etc/triliovault-datamover/triliovault-datamover.conf"
 DM_LOGGING_CONF_PATH = "/etc/triliovault-datamover/datamover_logging.conf"
-# nova.conf lives inside the openstack-hypervisor snap (root:root 640).
-# The charm copies it to a nova-readable location so tvault-contego can read it.
+# nova.conf lives inside the openstack-hypervisor snap (root:root 640, unreadable by
+# the nova user that tvault-contego runs as).  The charm copies it to NOVA_CONF_COPY
+# (root:nova 640) and rewrites the cafile= line to point to CA_BUNDLE_COPY instead
+# of the snap-internal path, which is also root-only.  The CA cert itself is obtained
+# from the receive-ca-cert Juju relation (not copied from the snap) and written to
+# CA_BUNDLE_COPY with root:nova 640 so the nova user can read it.
 SNAP_NOVA_CONF = "/var/snap/openstack-hypervisor/common/etc/nova/nova.conf"
 NOVA_CONF_COPY = "/etc/triliovault-datamover/nova.conf"
+CA_BUNDLE_COPY = "/etc/triliovault-datamover/ca-bundle.pem"
 DMS_CONFIG_PATH = "/etc/triliovault-dms/server.conf"
 DMS_CLIENT_CONF_PATH = "/etc/triliovault-dms/client.conf"
 S3VAULTFUSE_CONF = "/etc/triliovault-dms/s3vaultfuse-global.conf"
@@ -323,12 +329,12 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             return
 
         try:
+            self._write_ca_cert()
             self._sync_nova_conf()
             self._write_datamover_config()
             self._write_dms_config()
             self._write_dms_client_config()
             self._write_s3vaultfuse_config()
-            self._write_ca_cert()
             self._restart_services()
         except Exception as e:
             logger.error("Configuration failed: %s", e)
@@ -405,16 +411,30 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         return "\n".join(certs) if certs else None
 
     def _write_ca_cert(self):
-        """Write CA bundle to the host system for tvault-contego Keystone TLS verification."""
+        """Write CA bundle from the receive-ca-cert relation to host trust store and to
+        a nova-readable path so tvault-contego can verify Keystone TLS.
+
+        CA content comes from the Juju relation — not copied from any snap path.
+        CA_BUNDLE_COPY (root:nova 640) is written first so _sync_nova_conf() can
+        reference it in the cafile= patch.
+        """
         ca_cert = self._get_ca_cert()
         if not ca_cert:
             return
+        # Write to our managed path (root:nova 640) for direct use by tvault-contego
+        os.makedirs(os.path.dirname(CA_BUNDLE_COPY), exist_ok=True)
+        with open(CA_BUNDLE_COPY, "w") as f:
+            f.write(ca_cert)
+        shutil.chown(CA_BUNDLE_COPY, user="root", group="nova")
+        os.chmod(CA_BUNDLE_COPY, 0o640)
+        logger.info("CA cert written to %s (root:nova 640)", CA_BUNDLE_COPY)
+        # Also add to system trust store so other tools on this host trust the CA
         ca_path = "/usr/local/share/ca-certificates/trilio-ca.crt"
         os.makedirs(os.path.dirname(ca_path), exist_ok=True)
         with open(ca_path, "w") as f:
             f.write(ca_cert)
         subprocess.run(["update-ca-certificates"], check=True)
-        logger.info("CA cert written to %s", ca_path)
+        logger.info("CA cert added to system trust store via %s", ca_path)
 
     # --- apt repo and package installation ---
 
@@ -718,20 +738,40 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             f.write(OBJECT_STORE_LOGGING_CONF)
         logger.info("Wrote %s", OBJECT_STORE_LOGGING_CONF_PATH)
 
+    # Matches any cafile= line whose value starts with /var/snap/ — the snap-internal
+    # path is root-only; we replace it with CA_BUNDLE_COPY which is root:nova 640.
+    _SNAP_CAFILE_RE = re.compile(rb"(?m)^([ \t]*cafile[ \t]*=[ \t]*)/var/snap/[^\n]*")
+
     def _sync_nova_conf(self) -> bool:
         """Copy snap nova.conf to our location if content changed.
 
         The snap nova.conf is root:root 640 — unreadable by the nova user that
         tvault-contego runs as.  Charm hooks run as root, so we copy it to
-        NOVA_CONF_COPY (root:nova 640) and only write when content differs.
+        NOVA_CONF_COPY (root:nova 640).
+
+        The cafile= line in [keystone_authtoken] references a snap-internal path
+        (also root-only).  We rewrite it to CA_BUNDLE_COPY, which is written by
+        _write_ca_cert() from the receive-ca-cert relation (root:nova 640).
+        If no CA cert is available yet, the cafile= line is removed so
+        keystoneauth1 falls back to the system CA trust store.
+
         Returns True if the file was updated, False if nothing changed.
         """
         try:
             with open(SNAP_NOVA_CONF, "rb") as f:
-                new_content = f.read()
+                snap_content = f.read()
         except OSError as e:
             logger.warning("Cannot read snap nova.conf: %s", e)
             return False
+
+        # Patch cafile= to point to our nova-readable CA bundle (from relation).
+        if os.path.exists(CA_BUNDLE_COPY):
+            new_content = self._SNAP_CAFILE_RE.sub(
+                rb"\g<1>" + CA_BUNDLE_COPY.encode(), snap_content
+            )
+        else:
+            # CA not yet available — strip cafile so keystoneauth1 uses system store
+            new_content = self._SNAP_CAFILE_RE.sub(b"", snap_content)
 
         new_hash = hashlib.sha256(new_content).hexdigest()
 
@@ -749,7 +789,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             f.write(new_content)
         shutil.chown(NOVA_CONF_COPY, user="root", group="nova")
         os.chmod(NOVA_CONF_COPY, 0o640)
-        logger.info("Synced nova.conf from snap to %s", NOVA_CONF_COPY)
+        logger.info("Synced nova.conf from snap to %s (cafile patched)", NOVA_CONF_COPY)
         return True
 
     def _on_update_status(self, event):

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -255,6 +255,13 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             # Trilio releases and must be refreshed before installing the new package.
             self._setup_apt_repo()
             self._install_packages()
+            # Re-write systemd units on upgrade: the unit files may not have been
+            # written by the original install if this was a pre-v14 deployment, or
+            # the unit content may have changed between Trilio releases.
+            self._create_directories()
+            self._write_nova_sudoers()
+            self._install_rootwrap_filters()
+            self._write_systemd_services()
         except subprocess.CalledProcessError as e:
             self.unit.status = ops.BlockedStatus(f"Upgrade failed: {e}")
             return

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -20,6 +20,7 @@ and handle NFS / S3 mount operations on their respective hosts.
 """
 
 import configparser
+import hashlib
 import io
 import logging
 import os
@@ -37,6 +38,10 @@ DATAMOVER_SERVICE = "triliovault-datamover"
 DMS_SERVICE = "triliovault-dms"
 DM_CONFIG_PATH = "/etc/triliovault-datamover/triliovault-datamover.conf"
 DM_LOGGING_CONF_PATH = "/etc/triliovault-datamover/datamover_logging.conf"
+# nova.conf lives inside the openstack-hypervisor snap (root:root 640).
+# The charm copies it to a nova-readable location so tvault-contego can read it.
+SNAP_NOVA_CONF = "/var/snap/openstack-hypervisor/common/etc/nova/nova.conf"
+NOVA_CONF_COPY = "/etc/triliovault-datamover/nova.conf"
 DMS_CONFIG_PATH = "/etc/triliovault-dms/server.conf"
 DMS_CLIENT_CONF_PATH = "/etc/triliovault-dms/client.conf"
 S3VAULTFUSE_CONF = "/etc/triliovault-dms/s3vaultfuse-global.conf"
@@ -56,6 +61,7 @@ After=network.target
 User=nova
 Group=nova
 Type=simple
+Environment="PYTHONPATH=/snap/openstack-hypervisor/current/usr/lib/python3/dist-packages"
 ExecStart=/usr/bin/python3 /usr/bin/trilio-dms-server --config-file /etc/triliovault-dms/server.conf
 Restart=on-failure
 RestartSec=10
@@ -66,7 +72,10 @@ WantedBy=multi-user.target
 """
 
 # Systemd unit for tvault-contego on Sunbeam compute nodes.
-# Nova config lives inside the openstack-hypervisor snap, not /etc/nova/nova.conf.
+# nova.conf lives inside the openstack-hypervisor snap (root:root 640).
+# The charm copies it to NOVA_CONF_COPY (root:nova 640) so tvault-contego can
+# read it as the nova user.  PYTHONPATH is required because snap Python packages
+# (nova, kombu, etc.) are isolated from the host system path.
 DATAMOVER_SYSTEMD_UNIT = """\
 [Unit]
 Description=TrilioVault DataMover (tvault-contego)
@@ -78,12 +87,9 @@ StartLimitBurst=3
 User=nova
 Group=nova
 Type=simple
-# tvault-contego imports from nova (e.g. nova.exception). On Sunbeam compute nodes
-# nova runs inside the openstack-hypervisor snap; add the snap's dist-packages to
-# PYTHONPATH so tvault-contego can import nova and other OpenStack libraries.
 Environment="PYTHONPATH=/snap/openstack-hypervisor/current/usr/lib/python3/dist-packages"
 ExecStart=/usr/bin/python3 /usr/bin/tvault-contego \
-  --config-file=/var/snap/openstack-hypervisor/common/etc/nova/nova.conf \
+  --config-file=/etc/triliovault-datamover/nova.conf \
   --config-file=/etc/triliovault-datamover/triliovault-datamover.conf
 TimeoutStopSec=20
 KillMode=process
@@ -231,6 +237,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         self.framework.observe(
             self.on.receive_ca_cert_relation_changed, self._on_relation_changed
         )
+        self.framework.observe(self.on.update_status, self._on_update_status)
 
     # --- event handlers ---
 
@@ -316,6 +323,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             return
 
         try:
+            self._sync_nova_conf()
             self._write_datamover_config()
             self._write_dms_config()
             self._write_dms_client_config()
@@ -709,6 +717,52 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         with open(OBJECT_STORE_LOGGING_CONF_PATH, "w") as f:
             f.write(OBJECT_STORE_LOGGING_CONF)
         logger.info("Wrote %s", OBJECT_STORE_LOGGING_CONF_PATH)
+
+    def _sync_nova_conf(self) -> bool:
+        """Copy snap nova.conf to our location if content changed.
+
+        The snap nova.conf is root:root 640 — unreadable by the nova user that
+        tvault-contego runs as.  Charm hooks run as root, so we copy it to
+        NOVA_CONF_COPY (root:nova 640) and only write when content differs.
+        Returns True if the file was updated, False if nothing changed.
+        """
+        try:
+            with open(SNAP_NOVA_CONF, "rb") as f:
+                new_content = f.read()
+        except OSError as e:
+            logger.warning("Cannot read snap nova.conf: %s", e)
+            return False
+
+        new_hash = hashlib.sha256(new_content).hexdigest()
+
+        try:
+            with open(NOVA_CONF_COPY, "rb") as f:
+                old_hash = hashlib.sha256(f.read()).hexdigest()
+        except OSError:
+            old_hash = None
+
+        if new_hash == old_hash:
+            return False
+
+        os.makedirs(os.path.dirname(NOVA_CONF_COPY), exist_ok=True)
+        with open(NOVA_CONF_COPY, "wb") as f:
+            f.write(new_content)
+        shutil.chown(NOVA_CONF_COPY, user="root", group="nova")
+        os.chmod(NOVA_CONF_COPY, 0o640)
+        logger.info("Synced nova.conf from snap to %s", NOVA_CONF_COPY)
+        return True
+
+    def _on_update_status(self, event):
+        """Detect snap nova.conf changes and restart services only when content changed."""
+        if self._sync_nova_conf():
+            logger.info("nova.conf changed — restarting DataMover and DMS")
+            try:
+                subprocess.run(
+                    ["systemctl", "restart", DATAMOVER_SERVICE, DMS_SERVICE],
+                    check=True,
+                )
+            except subprocess.CalledProcessError as e:
+                self.unit.status = ops.BlockedStatus(f"Service restart failed: {e}")
 
     # --- service management ---
 

--- a/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
@@ -22,6 +22,7 @@ import configparser
 import io
 import json
 import logging
+import socket
 
 import ops
 
@@ -97,6 +98,9 @@ DMAPI_PORT = 8784
 #   Service Name=dmapi  Service Type=datamover
 DMAPI_SERVICE_TYPE = "datamover"
 DMAPI_SERVICE_NAME = "dmapi"
+# Traefik ingress name — determines the URL path prefix (/openstack-trilio-dm-api).
+# Use a fixed name without the -k8s suffix to match OpenStack service naming convention.
+DMAPI_INGRESS_NAME = "trilio-dm-api"
 
 
 class TrilioDmApiK8sCharm(ops.CharmBase):
@@ -504,27 +508,31 @@ class TrilioDmApiK8sCharm(ops.CharmBase):
         })
 
     def _publish_ingress(self, rel):
-        """Write traefik_k8s v2 ingress requirer data.
+        """Write traefik_k8s ingress requirer data.
 
-        Traefik v2 expects a single 'data' key whose value is a JSON-encoded
-        dict (not individual top-level keys). Port must be an integer.
-        Stale individual keys (model/name/port/scheme/strip-prefix/redirect-https)
-        from older charm versions are removed; their presence alongside 'data'
-        prevents Traefik from processing the relation.
+        Matches IngressPerAppRequirer from charms.traefik_k8s.v2.ingress:
+        - Leader writes app databag: model, name, port (individual JSON-encoded keys).
+        - Every unit writes its own unit databag: host, ip (required by Traefik's
+          is_ready validation before it will publish the ingress URL back).
         """
-        if not self.unit.is_leader():
-            return
-        for old_key in ("model", "name", "port", "scheme", "strip-prefix", "redirect-https"):
-            if old_key in rel.data[self.app]:
-                del rel.data[self.app][old_key]
-        rel.data[self.app]["data"] = json.dumps({
-            "model": self.model.name,
-            "name": self.app.name,
-            "port": DMAPI_PORT,
-            "scheme": "http",
-            "strip-prefix": False,
-            "redirect-https": False,
-        })
+        # App databag — leader only.
+        if self.unit.is_leader():
+            if "data" in rel.data[self.app]:
+                del rel.data[self.app]["data"]
+            rel.data[self.app]["model"] = json.dumps(self.model.name)
+            rel.data[self.app]["name"] = json.dumps(DMAPI_INGRESS_NAME)
+            rel.data[self.app]["port"] = json.dumps(DMAPI_PORT)
+        # Unit databag — every unit. Traefik validates host/ip for each unit
+        # before it considers the requirer ready and publishes the ingress URL.
+        binding = self.model.get_binding(rel)
+        ip = (
+            str(binding.network.bind_address)
+            if binding and binding.network.bind_address
+            else None
+        )
+        rel.data[self.unit]["host"] = json.dumps(socket.getfqdn())
+        if ip:
+            rel.data[self.unit]["ip"] = json.dumps(ip)
 
 
 if __name__ == "__main__":

--- a/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
@@ -98,9 +98,10 @@ DMAPI_PORT = 8784
 #   Service Name=dmapi  Service Type=datamover
 DMAPI_SERVICE_TYPE = "datamover"
 DMAPI_SERVICE_NAME = "dmapi"
-# Traefik ingress name — determines the URL path prefix (/openstack-trilio-dm-api).
-# Use a fixed name without the -k8s suffix to match OpenStack service naming convention.
-DMAPI_INGRESS_NAME = "trilio-dm-api"
+# Traefik ingress model+name — Traefik constructs the path as /{model}-{name}.
+# Setting model="trilio" and name="dm-api" gives path /trilio-dm-api (no openstack- prefix).
+DMAPI_INGRESS_MODEL = "trilio"
+DMAPI_INGRESS_NAME = "dm-api"
 
 
 class TrilioDmApiK8sCharm(ops.CharmBase):
@@ -519,7 +520,7 @@ class TrilioDmApiK8sCharm(ops.CharmBase):
         if self.unit.is_leader():
             if "data" in rel.data[self.app]:
                 del rel.data[self.app]["data"]
-            rel.data[self.app]["model"] = json.dumps(self.model.name)
+            rel.data[self.app]["model"] = json.dumps(DMAPI_INGRESS_MODEL)
             rel.data[self.app]["name"] = json.dumps(DMAPI_INGRESS_NAME)
             rel.data[self.app]["port"] = json.dumps(DMAPI_PORT)
         # Unit databag — every unit. Traefik validates host/ip for each unit

--- a/sunbeam-canonical/charms/trilio-dms-k8s/charmcraft.yaml
+++ b/sunbeam-canonical/charms/trilio-dms-k8s/charmcraft.yaml
@@ -46,9 +46,6 @@ requires:
   amqp:
     interface: rabbitmq
     limit: 1
-  identity-service:
-    interface: keystone
-    limit: 1
   receive-ca-cert:
     interface: certificate_transfer
     optional: true
@@ -63,6 +60,14 @@ config:
       type: int
       default: 10
       description: Number of worker threads for parallel mount request processing
+    keystone-endpoint:
+      type: string
+      default: "http://keystone-k8s.openstack.svc.cluster.local:5000/v3"
+      description: |
+        Keystone identity service internal URL used as auth_url in server.conf
+        for Barbican token validation. Defaults to the k8s-internal Keystone
+        service DNS name (standard for Sunbeam). Override only if your cluster
+        uses a different Keystone endpoint.
     wlm-db-url:
       type: string
       default: ""

--- a/sunbeam-canonical/charms/trilio-dms-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-dms-k8s/src/charm.py
@@ -8,18 +8,17 @@ operations on behalf of WLM and DMAPI. Communication is via RabbitMQ (no
 HTTP listener). A second DMS server instance runs on every compute node,
 managed by the trilio-data-mover machine subordinate charm.
 
+DMS does not register with Keystone and has no Keystone service user.
+The Keystone auth_url (used in server.conf for Barbican token validation)
+is supplied via the keystone-endpoint config option.
+
 Relation interface notes (Sunbeam Caracal):
   - amqp: rabbitmq interface — requirer writes username/vhost to its *app* databag
     (leader only); provider responds with hostname/password in its *app* databag.
-  - identity-service: keystone interface — requirer writes service-endpoints (JSON)
-    and region to its *app* databag (leader only); provider responds with service-host,
-    service-port, service-protocol in its *app* databag.
-    DMS only uses the auth URL (not service-credentials) for auth_url in server.conf.
 """
 
 import configparser
 import io
-import json
 import logging
 
 import ops
@@ -98,14 +97,8 @@ class TrilioDmsK8sCharm(ops.CharmBase):
         self.framework.observe(self.on.trilio_dms_pebble_ready, self._on_pebble_ready)
         self.framework.observe(self.on.config_changed, self._configure)
         self.framework.observe(self.on.upgrade_charm, self._configure)
-        for rel in ("amqp", "identity_service"):
-            self.framework.observe(
-                getattr(self.on, f"{rel}_relation_changed"), self._configure
-            )
+        self.framework.observe(self.on.amqp_relation_changed, self._configure)
         self.framework.observe(self.on.amqp_relation_joined, self._on_amqp_relation_joined)
-        self.framework.observe(
-            self.on.identity_service_relation_joined, self._on_identity_service_relation_joined
-        )
         self.framework.observe(
             self.on.receive_ca_cert_relation_changed, self._configure
         )
@@ -122,10 +115,6 @@ class TrilioDmsK8sCharm(ops.CharmBase):
             event.relation.data[self.app]["username"] = "dmapi"
             event.relation.data[self.app]["vhost"] = "dmapi"
 
-    def _on_identity_service_relation_joined(self, event):
-        """Register DMS with keystone so keystone writes its endpoint data back."""
-        self._register_keystone_service()
-
     def _send_relation_requests(self):
         """Idempotently write relation requests in case joined events were missed."""
         if not self.unit.is_leader():
@@ -134,9 +123,6 @@ class TrilioDmsK8sCharm(ops.CharmBase):
         if amqp_rel and not amqp_rel.data[self.app].get("username"):
             amqp_rel.data[self.app]["username"] = "dmapi"
             amqp_rel.data[self.app]["vhost"] = "dmapi"
-        ks_rel = self.model.get_relation("identity-service")
-        if ks_rel and not ks_rel.data[self.app].get("service-endpoints"):
-            self._register_keystone_service()
 
     def _configure(self, event):
         self._send_relation_requests()
@@ -162,8 +148,6 @@ class TrilioDmsK8sCharm(ops.CharmBase):
         missing = []
         if not self._amqp_data():
             missing.append("amqp")
-        if not self._identity_data():
-            missing.append("identity-service")
         return missing
 
     def _amqp_data(self):
@@ -176,47 +160,6 @@ class TrilioDmsK8sCharm(ops.CharmBase):
         if host and d.get("password"):
             return {**dict(d), "host": host}
         return None
-
-    def _identity_data(self):
-        """keystone interface: provider writes endpoint data into its app databag.
-
-        DMS only uses the keystone auth URL (no service-credentials needed).
-        service-host is written by keystone after DMS sends service-endpoints.
-        """
-        rel = self.model.get_relation("identity-service")
-        if not rel or not rel.app:
-            return None
-        d = rel.data[rel.app]
-        if not d.get("service-host"):
-            return None
-        return {
-            "service_host": d.get("service-host"),
-            "service_port": d.get("service-port", "5000"),
-            "service_protocol": d.get("service-protocol", "http"),
-        }
-
-    def _register_keystone_service(self):
-        """Write DMS service-endpoints to trigger keystone to respond with its endpoint data.
-
-        DMS has no HTTP listener but must register with keystone so keystone writes
-        service-host/service-port/service-protocol back to this relation's app databag.
-        """
-        rel = self.model.get_relation("identity-service")
-        if not rel or not self.unit.is_leader():
-            return
-        internal_url = f"http://{self.app.name}:8785"
-        endpoints = [{
-            "admin_url": internal_url,
-            "description": "TrilioVault Dynamic Mount Service",
-            "internal_url": internal_url,
-            "public_url": internal_url,
-            "service_name": "trilio-dms-k8s",
-            "type": "dms",
-        }]
-        rel.data[self.app].update({
-            "service-endpoints": json.dumps(endpoints, sort_keys=True),
-            "region": self.config.get("region", "RegionOne"),
-        })
 
     def _get_ca_cert(self):
         """Return concatenated CA certs from receive-ca-cert relation, or None."""
@@ -260,17 +203,13 @@ class TrilioDmsK8sCharm(ops.CharmBase):
 
     def _write_config(self, container):
         amqp = self._amqp_data()
-        identity = self._identity_data()
 
         transport_url = (
             f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
             f"/{amqp.get('vhost', 'dmapi')}"
         )
-        auth_url = (
-            f"{identity.get('service_protocol', 'http')}://"
-            f"{identity['service_host']}:{identity.get('service_port', '5000')}/v3"
-        )
+        auth_url = self.config["keystone-endpoint"]
 
         cfg = configparser.ConfigParser()
         cfg["server"] = {

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/actions.yaml
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/actions.yaml
@@ -1,0 +1,33 @@
+create-cloud-admin-trust:
+  description: |
+    Create trust between the TrilioVault WLM service user and the Cloud Admin.
+    This is required once after initial deployment before using TrilioVault.
+
+    Example:
+      juju run trilio-wlm-k8s/leader create-cloud-admin-trust password=<admin-password>
+  params:
+    password:
+      type: string
+      description: Cloud admin account password
+    user-domain-name:
+      type: string
+      description: Admin user domain name
+      default: admin_domain
+    project-name:
+      type: string
+      description: Admin project name
+      default: admin
+    project-domain-name:
+      type: string
+      description: Admin project domain name
+      default: admin_domain
+  required:
+    - password
+
+create-license:
+  description: |
+    Apply the TrilioVault license file.
+    Attach the license file as a Juju resource first, then run this action:
+
+      juju attach-resource trilio-wlm-k8s license=<path-to-license-file>
+      juju run trilio-wlm-k8s/leader create-license

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/charmcraft.yaml
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/charmcraft.yaml
@@ -35,6 +35,9 @@ resources:
     type: oci-image
     description: OCI image for TrilioVault WorkloadManager
     upstream-source: docker.io/trilio/trilio-wlm-canonical:6.2.1-2024.1
+  license:
+    type: file
+    description: TrilioVault license file. Attach with juju attach-resource trilio-wlm-k8s license=<path>
 
 requires:
   database:

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/charmcraft.yaml
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/charmcraft.yaml
@@ -37,6 +37,7 @@ resources:
     upstream-source: docker.io/trilio/trilio-wlm-canonical:6.2.1-2024.1
   license:
     type: file
+    filename: license
     description: TrilioVault license file. Attach with juju attach-resource trilio-wlm-k8s license=<path>
 
 requires:

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -247,7 +247,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             "trust-create", "--is_cloud_trust", "True", "Admin",
         ]
         try:
-            out, err = container.exec(cmd).wait_output()
+            out, err = container.exec(cmd, environment={"TERM": "xterm"}).wait_output()
             logger.info("trust-create output: %s", out)
             event.set_results({"result": "Cloud admin trust created successfully"})
         except Exception as e:
@@ -299,12 +299,13 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             "--os-password", identity["service_password"],
             "--os-auth-url", auth_url,
             "--os-user-domain-name", "service_domain",
+            "--os-project-domain-name", "service_domain",
             "--os-project-name", identity["service_tenant"],
             "--os-region-name", self.config.get("region", "RegionOne"),
             "license-create", container_license_path,
         ]
         try:
-            out, err = container.exec(cmd).wait_output()
+            out, err = container.exec(cmd, environment={"TERM": "xterm"}).wait_output()
             logger.info("license-create output: %s", out)
             event.set_results({"result": "License applied successfully"})
         except Exception as e:

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -31,10 +31,56 @@ logger = logging.getLogger(__name__)
 
 CONTAINER = "trilio-wlm"
 CONFIG_PATH = "/etc/triliovault-wlm/triliovault-wlm.conf"
+API_PASTE_PATH = "/etc/triliovault-wlm/api-paste.ini"
 WLM_LOGGING_CONF_PATH = "/etc/triliovault-wlm/wlm_logging.conf"
 DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf"
 S3VAULTFUSE_CONF = "/etc/triliovault-dms/s3vaultfuse-global.conf"
 LOG_DIR = "/var/log/triliovault"
+
+# The api-paste.ini shipped by the WLM deb package contains legacy
+# %SERVICE_TENANT_NAME% / %SERVICE_USER% / %SERVICE_PASSWORD% placeholders.
+# Python's configparser treats % as an interpolation prefix and raises
+# InterpolationSyntaxError when it sees %S (not %(key)s format), crashing
+# wlm-api on startup. The charm overwrites the file with this clean version
+# that removes the deprecated auth fields (keystonemiddleware reads credentials
+# from [keystone_authtoken] in the main config anyway).
+WLM_API_PASTE = """\
+[composite:osapi_workloads]
+use = call:workloadmgr.api:root_app_factory
+/: apiversions
+/v1: openstack_workloads_api_v1
+
+[composite:openstack_workloads_api_v1]
+use = call:workloadmgr.api.middleware.auth:pipeline_factory
+noauth = faultwrap sizelimit noauth apiv1
+keystone = faultwrap sizelimit authtoken keystonecontext apiv1
+keystone_nolimit = faultwrap sizelimit authtoken keystonecontext apiv1
+
+[filter:faultwrap]
+paste.filter_factory = workloadmgr.api.middleware.fault:FaultWrapper.factory
+
+[filter:noauth]
+paste.filter_factory = workloadmgr.api.middleware.auth:NoAuthMiddleware.factory
+
+[filter:sizelimit]
+paste.filter_factory = oslo_middleware.sizelimit:RequestBodySizeLimiter.factory
+
+[app:apiv1]
+paste.app_factory = workloadmgr.api.v1.router:APIRouter.factory
+
+[pipeline:apiversions]
+pipeline = faultwrap osworkloadsversionapp
+
+[app:osworkloadsversionapp]
+paste.app_factory = workloadmgr.api.versions:Versions.factory
+
+[filter:keystonecontext]
+paste.filter_factory = workloadmgr.api.middleware.auth:WorkloadMgrKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+signing_dir = /var/cache/workloadmgr
+"""
 
 # Python logging config pushed into the container by the charm (not baked into the image).
 # Matches the RHOSO18 _wlm_logging_conf.tpl reference.
@@ -447,7 +493,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
     def _get_ca_bundle_env(self):
         """Return env dict with REQUESTS_CA_BUNDLE when a CA cert is configured."""
         if self._get_ca_cert():
-            return {"REQUESTS_CA_BUNDLE": "/usr/local/share/ca-certificates/ca-bundle.pem"}
+            return {"REQUESTS_CA_BUNDLE": "/usr/local/share/ca-certificates/ca-bundle.crt"}
         return {}
 
     def _write_ca_cert(self, container):
@@ -455,8 +501,9 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         ca_cert = self._get_ca_cert()
         if not ca_cert:
             return
+        # update-ca-certificates only processes *.crt files — must use .crt extension
         container.push(
-            "/usr/local/share/ca-certificates/ca-bundle.pem",
+            "/usr/local/share/ca-certificates/ca-bundle.crt",
             ca_cert,
             make_dirs=True,
         )
@@ -601,6 +648,8 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         logger.info("Wrote %s", CONFIG_PATH)
         container.push(WLM_LOGGING_CONF_PATH, WLM_LOGGING_CONF, make_dirs=True)
         logger.info("Wrote %s", WLM_LOGGING_CONF_PATH)
+        container.push(API_PASTE_PATH, WLM_API_PASTE, make_dirs=True)
+        logger.info("Wrote %s", API_PASTE_PATH)
 
     def _write_dms_client_config(self, container):
         """Write DMS client config for the trilio-dms client library inside WLM."""

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -23,6 +23,7 @@ import configparser
 import io
 import json
 import logging
+import socket
 
 import ops
 
@@ -134,6 +135,9 @@ WLM_SERVICE_TYPE = "workloads"
 WLM_SERVICE_NAME = "TrilioVaultWLM"
 # Endpoint path template matching production WLM endpoint format.
 WLM_ENDPOINT_TEMPLATE = "{}/v1/$(tenant_id)s"
+# Traefik ingress name — determines the URL path prefix (/openstack-trilio-wlm).
+# Use a fixed name without the -k8s suffix to match OpenStack service naming convention.
+WLM_INGRESS_NAME = "trilio-wlm"
 
 
 class TrilioWlmK8sCharm(ops.CharmBase):
@@ -635,27 +639,31 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         })
 
     def _publish_ingress(self, rel):
-        """Write traefik_k8s v2 ingress requirer data.
+        """Write traefik_k8s ingress requirer data.
 
-        Traefik v2 expects a single 'data' key whose value is a JSON-encoded
-        dict (not individual top-level keys). Port must be an integer.
-        Stale individual keys (model/name/port/scheme/strip-prefix/redirect-https)
-        from older charm versions are removed; their presence alongside 'data'
-        prevents Traefik from processing the relation.
+        Matches IngressPerAppRequirer from charms.traefik_k8s.v2.ingress:
+        - Leader writes app databag: model, name, port (individual JSON-encoded keys).
+        - Every unit writes its own unit databag: host, ip (required by Traefik's
+          is_ready validation before it will publish the ingress URL back).
         """
-        if not self.unit.is_leader():
-            return
-        for old_key in ("model", "name", "port", "scheme", "strip-prefix", "redirect-https"):
-            if old_key in rel.data[self.app]:
-                del rel.data[self.app][old_key]
-        rel.data[self.app]["data"] = json.dumps({
-            "model": self.model.name,
-            "name": self.app.name,
-            "port": WLM_PORT,
-            "scheme": "http",
-            "strip-prefix": False,
-            "redirect-https": False,
-        })
+        # App databag — leader only.
+        if self.unit.is_leader():
+            if "data" in rel.data[self.app]:
+                del rel.data[self.app]["data"]
+            rel.data[self.app]["model"] = json.dumps(self.model.name)
+            rel.data[self.app]["name"] = json.dumps(WLM_INGRESS_NAME)
+            rel.data[self.app]["port"] = json.dumps(WLM_PORT)
+        # Unit databag — every unit. Traefik validates host/ip for each unit
+        # before it considers the requirer ready and publishes the ingress URL.
+        binding = self.model.get_binding(rel)
+        ip = (
+            str(binding.network.bind_address)
+            if binding and binding.network.bind_address
+            else None
+        )
+        rel.data[self.unit]["host"] = json.dumps(socket.getfqdn())
+        if ip:
+            rel.data[self.unit]["ip"] = json.dumps(ip)
 
 
 if __name__ == "__main__":

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -247,8 +247,8 @@ class TrilioWlmK8sCharm(ops.CharmBase):
     def _on_amqp_relation_joined(self, event):
         """Write rabbitmq requirer credentials so rabbitmq-k8s provisions the user/vhost."""
         if self.unit.is_leader():
-            event.relation.data[self.app]["username"] = "workloadmgr"
-            event.relation.data[self.app]["vhost"] = "workloadmgr"
+            event.relation.data[self.app]["username"] = "wlm"
+            event.relation.data[self.app]["vhost"] = "wlm"
 
     def _on_database_relation_joined(self, event):
         """Write mysql requirer database name so mysql-k8s provisions the database."""
@@ -377,8 +377,8 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             return
         amqp_rel = self.model.get_relation("amqp")
         if amqp_rel:
-            amqp_rel.data[self.app]["username"] = "workloadmgr"
-            amqp_rel.data[self.app]["vhost"] = "workloadmgr"
+            amqp_rel.data[self.app]["username"] = "wlm"
+            amqp_rel.data[self.app]["vhost"] = "wlm"
         db_rel = self.model.get_relation("database")
         if db_rel and not db_rel.data[self.app].get("database"):
             db_rel.data[self.app]["database"] = "workloadmgr"
@@ -539,9 +539,9 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         )
 
         transport_url = (
-            f"rabbit://{amqp.get('username', 'workloadmgr')}:{amqp['password']}"
+            f"rabbit://{amqp.get('username', 'wlm')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
-            f"/{amqp.get('vhost', 'workloadmgr')}"
+            f"/{amqp.get('vhost', 'wlm')}"
         )
         auth_url = (
             f"{identity.get('service_protocol', 'http')}://"
@@ -590,7 +590,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             "cinder_production_endpoint_template": self.config["cinder-endpoint"],
             "taskflow_path": "/var/lib/workloadmgr/taskflow",
             "taskflow_max_cache_size": "1024",
-            "rabbit_virtual_host": amqp.get("vhost", "workloadmgr"),
+            "rabbit_virtual_host": amqp.get("vhost", "wlm"),
             "compute_driver": "libvirt.LibvirtDriver",
             "max_wait_for_upload": "48",
             "vault_storage_das_device": "none",
@@ -665,9 +665,9 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             f"@{db_host}:{db_port}/{db['database']}"
         )
         rabbitmq_url = (
-            f"rabbit://{amqp.get('username', 'workloadmgr')}:{amqp['password']}"
+            f"rabbit://{amqp.get('username', 'wlm')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
-            f"/{amqp.get('vhost', 'workloadmgr')}"
+            f"/{amqp.get('vhost', 'wlm')}"
         )
 
         cfg = configparser.ConfigParser()

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -170,6 +170,10 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         self.framework.observe(
             self.on.receive_ca_cert_relation_changed, self._configure
         )
+        self.framework.observe(
+            self.on.create_cloud_admin_trust_action, self._on_create_trust_action
+        )
+        self.framework.observe(self.on.create_license_action, self._on_create_license_action)
 
     # --- event handlers ---
 
@@ -208,6 +212,108 @@ class TrilioWlmK8sCharm(ops.CharmBase):
     def _on_identity_service_relation_joined(self, event):
         """Write keystone service registration so keystone creates the service endpoints."""
         self._register_keystone_service()
+
+    def _on_create_trust_action(self, event):
+        """Action: create trust between WLM service user and Cloud Admin.
+
+        Must be run once after deployment before TrilioVault can perform backups.
+        Runs 'workloadmgr trust-create' inside the workload container using the
+        admin credentials supplied as action params.
+        """
+        if not self.unit.is_leader():
+            event.fail("Run this action on the leader unit only")
+            return
+        identity = self._identity_data()
+        if not identity:
+            event.fail("identity-service relation not ready — wait for charm to reach active status")
+            return
+        container = self.unit.get_container(CONTAINER)
+        if not container.can_connect():
+            event.fail("Workload container not ready")
+            return
+        auth_url = (
+            f"{identity['service_protocol']}://"
+            f"{identity['service_host']}:{identity['service_port']}/v3"
+        )
+        cmd = [
+            "workloadmgr",
+            "--os-username", "admin",
+            "--os-password", event.params["password"],
+            "--os-auth-url", auth_url,
+            "--os-user-domain-name", event.params.get("user-domain-name", "admin_domain"),
+            "--os-project-name", event.params.get("project-name", "admin"),
+            "--os-project-domain-name", event.params.get("project-domain-name", "admin_domain"),
+            "--os-region-name", self.config.get("region", "RegionOne"),
+            "trust-create", "--is_cloud_trust", "True", "Admin",
+        ]
+        try:
+            out, err = container.exec(cmd).wait_output()
+            logger.info("trust-create output: %s", out)
+            event.set_results({"result": "Cloud admin trust created successfully"})
+        except Exception as e:
+            event.fail(f"trust-create failed: {e}")
+
+    def _on_create_license_action(self, event):
+        """Action: apply TrilioVault license.
+
+        The license file must be attached as a Juju resource first:
+          juju attach-resource trilio-wlm-k8s license=<path-to-license-file>
+
+        Runs 'workloadmgr license-create' inside the workload container using the
+        WLM service credentials from the identity-service relation.
+        """
+        if not self.unit.is_leader():
+            event.fail("Run this action on the leader unit only")
+            return
+        identity = self._identity_data()
+        if not identity:
+            event.fail("identity-service relation not ready — wait for charm to reach active status")
+            return
+        container = self.unit.get_container(CONTAINER)
+        if not container.can_connect():
+            event.fail("Workload container not ready")
+            return
+        try:
+            license_path = self.model.resources.fetch("license")
+        except Exception:
+            event.fail(
+                "License resource not attached. Run: "
+                "juju attach-resource trilio-wlm-k8s license=<path-to-license-file>"
+            )
+            return
+        if not license_path.stat().st_size:
+            event.fail(
+                "License resource is empty. Attach the license file first: "
+                "juju attach-resource trilio-wlm-k8s license=<path-to-license-file>"
+            )
+            return
+        container_license_path = "/tmp/trilio-license.dat"
+        container.push(container_license_path, license_path.read_bytes(), make_dirs=True)
+        auth_url = (
+            f"{identity['service_protocol']}://"
+            f"{identity['service_host']}:{identity['service_port']}/v3"
+        )
+        cmd = [
+            "workloadmgr",
+            "--os-username", identity["service_username"],
+            "--os-password", identity["service_password"],
+            "--os-auth-url", auth_url,
+            "--os-user-domain-name", "service_domain",
+            "--os-project-name", identity["service_tenant"],
+            "--os-region-name", self.config.get("region", "RegionOne"),
+            "license-create", container_license_path,
+        ]
+        try:
+            out, err = container.exec(cmd).wait_output()
+            logger.info("license-create output: %s", out)
+            event.set_results({"result": "License applied successfully"})
+        except Exception as e:
+            event.fail(f"license-create failed: {e}")
+        finally:
+            try:
+                container.exec(["rm", "-f", container_license_path]).wait()
+            except Exception:
+                pass
 
     def _send_relation_requests(self):
         """Write requirer data to all relations. Idempotent — safe to call on every configure.

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -235,7 +235,10 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             f"{identity['service_protocol']}://"
             f"{identity['service_host']}:{identity['service_port']}/v3"
         )
+        # setsid detaches the process from Pebble's controlling terminal so that
+        # workloadmgr's cliff/cmd2 cannot open /dev/tty and skips curses init.
         cmd = [
+            "setsid",
             "workloadmgr",
             "--os-username", "admin",
             "--os-password", event.params["password"],
@@ -293,7 +296,10 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             f"{identity['service_protocol']}://"
             f"{identity['service_host']}:{identity['service_port']}/v3"
         )
+        # setsid detaches the process from Pebble's controlling terminal so that
+        # workloadmgr's cliff/cmd2 cannot open /dev/tty and skips curses init.
         cmd = [
+            "setsid",
             "workloadmgr",
             "--os-username", identity["service_username"],
             "--os-password", identity["service_password"],

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -135,9 +135,10 @@ WLM_SERVICE_TYPE = "workloads"
 WLM_SERVICE_NAME = "TrilioVaultWLM"
 # Endpoint path template matching production WLM endpoint format.
 WLM_ENDPOINT_TEMPLATE = "{}/v1/$(tenant_id)s"
-# Traefik ingress name — determines the URL path prefix (/openstack-trilio-wlm).
-# Use a fixed name without the -k8s suffix to match OpenStack service naming convention.
-WLM_INGRESS_NAME = "trilio-wlm"
+# Traefik ingress model+name — Traefik constructs the path as /{model}-{name}.
+# Setting model="trilio" and name="wlm" gives path /trilio-wlm (no openstack- prefix).
+WLM_INGRESS_MODEL = "trilio"
+WLM_INGRESS_NAME = "wlm"
 
 
 class TrilioWlmK8sCharm(ops.CharmBase):
@@ -650,7 +651,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         if self.unit.is_leader():
             if "data" in rel.data[self.app]:
                 del rel.data[self.app]["data"]
-            rel.data[self.app]["model"] = json.dumps(self.model.name)
+            rel.data[self.app]["model"] = json.dumps(WLM_INGRESS_MODEL)
             rel.data[self.app]["name"] = json.dumps(WLM_INGRESS_NAME)
             rel.data[self.app]["port"] = json.dumps(WLM_PORT)
         # Unit databag — every unit. Traefik validates host/ip for each unit

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -552,6 +552,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
 
         cfg["DEFAULT"] = {
             "transport_url": transport_url,
+            "sql_connection": db_url,
             "auth_strategy": "keystone",
             "log_dir": LOG_DIR,
             # Write to stderr in addition to the log file so Pebble captures output


### PR DESCRIPTION
## Summary

Follow-on fixes to the Sunbeam native Juju charm implementation (continuing from #1520):

- **trilio-data-mover-sunbeam**: Fix `identity-credentials` interface key mismatch (charm was reading wrong keys from Keystone credentials relation); fix RabbitMQ transport URL (vhost must be `dmapi`, not blank); request external hostname from RabbitMQ so compute-node DMS clients can connect; write systemd units on upgrade-charm event; copy `/var/snap/openstack-hypervisor/common/etc/nova/nova.conf` for nova-user-readable access; set `PYTHONPATH` to include snap nova packages; fix CA cert path for tvault-contego Keystone TLS validation
- **trilio-dms-k8s**: Remove `identity-service` relation entirely — DMS has no HTTP listener, communicates via RabbitMQ only, and does not need a Keystone service user or catalog endpoints. The Keystone auth_url (for Barbican token validation) is now supplied via a new `keystone-endpoint` config option with default `http://keystone-k8s.openstack.svc.cluster.local:5000/v3` (matches kolla-ansible pattern of `keystone_internal_url` as a plain URL variable)

## Test plan

- [ ] Deploy trilio-data-mover-sunbeam on a compute node running `openstack-hypervisor` snap
- [ ] Verify tvault-contego starts and registers with Keystone via identity-credentials (no service/endpoint created)
- [ ] Verify DMS server.conf contains correct `auth_url` from `keystone-endpoint` config
- [ ] Run `openstack endpoint list` — confirm no DMS endpoints appear in the catalog
- [ ] Verify RabbitMQ connection from compute node to control plane using the external hostname

🤖 Generated with [Claude Code](https://claude.com/claude-code)