### PR TITLE
TVAULT-7404: Fix Sunbeam bundle, install script, and README against test findings

### DIFF
--- a/sunbeam-canonical/README.md
+++ b/sunbeam-canonical/README.md
@@ -98,7 +98,18 @@ juju attach-resource horizon-k8s \
 
 Horizon reloads automatically — no restart required.
 
-### 4. Cloud Admin Trust
+### 4. CA Certificate (TLS)
+
+If your Sunbeam deployment uses TLS (self-signed or Vault), relate the WLM charm to Keystone's CA cert distributor so Python's `requests` library trusts internal endpoints:
+
+```bash
+juju switch openstack
+juju relate trilio-wlm-k8s:receive-ca-cert keystone:send-ca-cert
+```
+
+This is required for WLM to reach Keystone over HTTPS. Skip if your cluster runs plain HTTP.
+
+### 5. Cloud Admin Trust
 
 TrilioVault needs a trust relationship between the WLM service user and the Cloud Admin
 so it can impersonate tenants during backup and restore operations.
@@ -115,7 +126,7 @@ Optional params (defaults work for standard Sunbeam deployments):
 - `project-name` (default: `admin`)
 - `project-domain-name` (default: `admin_domain`)
 
-### 5. Apply License
+### 6. Apply License
 
 Attach the TrilioVault license file and apply it:
 
@@ -166,14 +177,17 @@ Dockerfiles are in `docker/`:
 
 | Image | Dockerfile | Used by |
 |-------|-----------|---------|
-| `docker.io/trilio/trilio-wlm-canonical` | `docker/sunbeam-canonical/trilio-wlm/Dockerfile_2024.1` | `trilio-wlm-k8s` |
-| `docker.io/trilio/trilio-datamover-api-canonical` | `docker/sunbeam-canonical/trilio-datamover-api/Dockerfile_2024.1` | `trilio-dm-api-k8s` |
-| `docker.io/trilio/trilio-dms-canonical` | `docker/sunbeam-canonical/trilio-dms/Dockerfile_2024.1` | `trilio-dms-k8s` |
-| `docker.io/trilio/trilio-horizon-plugin-canonical` | `docker/sunbeam-canonical/trilio-horizon-plugin/Dockerfile_2024.1` | `horizon-k8s` attach-resource |
+| `docker.io/trilio/trilio-wlm-canonical` | `sunbeam-canonical/docker/trilio-wlm/Dockerfile_2024.1` | `trilio-wlm-k8s` |
+| `docker.io/trilio/trilio-datamover-api-canonical` | `sunbeam-canonical/docker/trilio-datamover-api/Dockerfile_2024.1` | `trilio-dm-api-k8s` |
+| `docker.io/trilio/trilio-dms-canonical` | `sunbeam-canonical/docker/trilio-dms/Dockerfile` | `trilio-dms-k8s` |
+| `docker.io/trilio/trilio-horizon-plugin-canonical` | `sunbeam-canonical/docker/trilio-horizon-plugin/Dockerfile_2024.1` | `horizon-k8s` attach-resource |
 
 Build and publish all images:
 
 ```bash
-cd docker/sunbeam-canonical
-bash devops-build-publish.sh 6.2.1-2024.1
+cd sunbeam-canonical/docker
+bash devops-build-publish.sh \
+  --tag 6.2.1-2024.1 \
+  --containers all \
+  --mode build-and-publish
 ```

--- a/sunbeam-canonical/install.sh
+++ b/sunbeam-canonical/install.sh
@@ -55,6 +55,13 @@ juju wait-for application trilio-wlm-k8s    --query='status=="active"' --timeout
 juju wait-for application trilio-dm-api-k8s --query='status=="active"' --timeout=10m
 juju wait-for application trilio-dms-k8s    --query='status=="active"' --timeout=10m
 
+# --- Step 2b: CA certificate relation (TLS) ---
+# Relates WLM to Keystone's CA cert distributor so Python's requests library
+# trusts internal HTTPS endpoints. Safe to run even if cluster uses plain HTTP
+# (the relation will simply carry no data).
+log "Relating trilio-wlm-k8s to keystone CA cert distributor..."
+juju relate trilio-wlm-k8s:receive-ca-cert keystone:send-ca-cert || true
+
 # --- Step 3: Deploy data plane bundle ---
 log "Deploying TrilioVault data plane into model: $DATAPLANE_MODEL"
 juju switch "$DATAPLANE_MODEL"

--- a/sunbeam-canonical/trilio-ctlplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-ctlplane-bundle.yaml
@@ -59,5 +59,5 @@ relations:
   - [trilio-dm-api-k8s:wlm-service, trilio-wlm-k8s:wlm-service]
 
   # DMS (Dynamic Mount Service) relations — control plane instance
+  # DMS communicates via RabbitMQ only; it has no HTTP listener and does not register with Keystone.
   - [trilio-dms-k8s:amqp, rabbitmq:amqp]
-  - [trilio-dms-k8s:identity-service, keystone:identity-service]


### PR DESCRIPTION
## Summary

Fixes discovered during end-to-end testing of the Sunbeam charm deployment after PR #1521 was merged.

- **`trilio-ctlplane-bundle.yaml`**: Remove `identity-service` relation for `trilio-dms-k8s`. DMS has no HTTP listener and communicates via RabbitMQ only — the Keystone relation caused `juju deploy` to fail on a fresh install.
- **`install.sh`**: Add `juju relate trilio-wlm-k8s:receive-ca-cert keystone:send-ca-cert` step after control plane deploy, so WLM trusts internal Keystone HTTPS endpoints automatically.
- **`README.md`**: Add CA cert relation step to manual deployment instructions (renumber steps 4→5, 5→6); fix Docker image Dockerfile paths (`sunbeam-canonical/docker/` not `docker/sunbeam-canonical/`); note `trilio-dms` uses `Dockerfile` not `Dockerfile_2024.1`; fix `devops-build-publish.sh` invocation to use named flags.

## Test plan

- [x] `juju deploy ./trilio-ctlplane-bundle.yaml` succeeds without Keystone error for DMS
- [x] `install.sh` runs `receive-ca-cert` relate step automatically
- [x] All four WLM Pebble services active after deploy (wlm-api, wlm-workloads, wlm-scheduler, wlm-cron)
- [x] `create-cloud-admin-trust` and `create-license` actions succeed on deployed charm

🤖 Generated with [Claude Code](https://claude.ai/claude-code)