### PR TITLE
TVAULT-7404: Fix keystone_authtoken domain — read service_domain_name from identity-service relation

### DIFF
--- a/sunbeam-canonical/CLAUDE.md
+++ b/sunbeam-canonical/CLAUDE.md
@@ -82,9 +82,11 @@ Run only on the leader unit (idempotent — safe to re-run). Follows the `ops_su
 ### TLS / CA certificate handling (k8s charms)
 All three k8s charms support the `receive-ca-cert` relation (`certificate_transfer` interface):
 - Requirer reads `ca` key from each provider unit databag
-- Pushes concatenated CA bundle to `/usr/local/share/ca-certificates/ca-bundle.pem` inside the container
+- Pushes concatenated CA bundle to `/usr/local/share/ca-certificates/ca-bundle.crt` inside the container (must be `.crt`, not `.pem` — `update-ca-certificates` only processes `*.crt` files)
 - Runs `update-ca-certificates` in the container
 - Sets `REQUESTS_CA_BUNDLE` env var on all Pebble services so Python's `requests` library trusts the CA
+
+**`receive-ca-cert` is required for all Sunbeam Trilio k8s charms** — without it, keystonemiddleware fails TLS verification when calling the Keystone HTTPS public endpoint, returning 503 "Keystone service temporarily unavailable" on every API request. Add `juju relate trilio-wlm-k8s:receive-ca-cert keystone:send-ca-cert` (and same for dmapi/dms) on fresh deployments.
 
 The DataMover machine charm writes the CA to the host (`/usr/local/share/ca-certificates/trilio-ca.crt`) and runs `update-ca-certificates` on the host.
 
@@ -105,6 +107,9 @@ This issue does NOT appear with `kubectl exec -- bash -c '...'` because that pat
 
 ### api-paste.ini — charm must overwrite package file
 The `api-paste.ini` shipped by the `workloadmgr` deb package contains legacy `%SERVICE_TENANT_NAME%`, `%SERVICE_USER%`, `%SERVICE_PASSWORD%` placeholders. Python's `configparser` raises `InterpolationSyntaxError` on `%` that aren't valid `%(var)s` interpolation, crashing wlm-api on startup. Fix: the WLM charm writes a clean `WLM_API_PASTE` constant directly to `/etc/triliovault-wlm/api-paste.ini` in `_write_config()`, overwriting the package-shipped file. The removed `[filter:authtoken]` password fields are NOT needed — keystonemiddleware reads auth from `[keystone_authtoken]` in the main conf.
+
+### keystone_authtoken domain — read from identity-service relation, not hardcoded
+WLM and DMAPI use `[keystone_authtoken]` with `user_domain_name` and `project_domain_name`. On Sunbeam, keystone-k8s creates service users in `service_domain`, **not** `Default`. The charms read `service-domain-name` from the identity-service relation app databag and pass it as `service_domain_name` to the config template. **Do NOT hardcode `Default`** — this causes keystonemiddleware 401 on the service-user auth call → 503 "Keystone service temporarily unavailable" on every API request.
 
 ### sql_connection in [DEFAULT] — not [database]
 WLM reads the DB URL from `sql_connection` in the `[DEFAULT]` section, **not** from `connection` in `[database]`. All other deployment methods (RHOSP17, RHOSO18, Kolla) all use `sql_connection` in `[DEFAULT]`. The `[database]` section with `connection` key is a newer Oslo convention that WLM does not use. Both must be present: `[DEFAULT].sql_connection` for WLM's own DB access, and `[alembic].sqlalchemy.url` for alembic migrations.
@@ -176,7 +181,7 @@ Our Trilio k8s charms use **plain `ops`** (not `ops_sunbeam`) to avoid the frame
 |---|---|---|---|
 | `database` | `mysql_client` | mysql-k8s | Req writes `database` to app databag; prov writes `endpoints`, `username`, `password` |
 | `amqp` | `rabbitmq` | rabbitmq-k8s | Req writes `username`, `vhost` to **app** databag (leader only); prov writes `hostname`, `password` to prov **app** databag |
-| `identity-service` | `keystone` | keystone-k8s | Req writes `service-endpoints` (JSON), `region` to **app** databag (leader only); prov writes `service-host`, `service-credentials` (Juju secret) to prov **app** databag |
+| `identity-service` | `keystone` | keystone-k8s | Req writes `service-endpoints` (JSON), `region` to **app** databag (leader only); prov writes `service-host`, `service-port`, `service-protocol`, `service-project-name`, `service-domain-name`, `service-credentials` (Juju secret) to prov **app** databag |
 | `receive-ca-cert` | `certificate_transfer` | vault-k8s / self-signed | Prov writes `ca` to unit databag |
 | `wlm-service` | custom | trilio-wlm-k8s | Provider writes `wlm-api-url` to app databag |
 | `ingress-internal` | `traefik_k8s` v2 | traefik-k8s | Req writes `model`, `name`, `port`, `scheme` to app databag; prov writes `{"ingress": '{"url": "https://IP:443/model-app"}'}` to prov **app** databag |

--- a/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 CONTAINER = "trilio-dm-api"
 CONFIG_PATH = "/etc/triliovault-datamover/triliovault-datamover-api.conf"
 DMAPI_LOGGING_CONF_PATH = "/etc/triliovault-datamover/datamover_api_logging.conf"
+DMAPI_API_PASTE_PATH = "/etc/triliovault-datamover/api-paste.ini"
 DMS_CLIENT_CONF = "/etc/triliovault-dms/client.conf"
 LOG_DIR = "/var/log/triliovault"
 
@@ -45,6 +46,7 @@ DMAPI_INGRESS_MODEL = "trilio"
 DMAPI_INGRESS_NAME = "dm-api"
 CA_BUNDLE_PATH = "/usr/local/share/ca-certificates/ca-bundle.crt"
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
+
 
 
 class TrilioDmApiK8sCharm(ops.CharmBase):
@@ -325,6 +327,13 @@ class TrilioDmApiK8sCharm(ops.CharmBase):
             make_dirs=True,
         )
         logger.info("Wrote %s", DMAPI_LOGGING_CONF_PATH)
+        traefik_prefix = f"/{DMAPI_INGRESS_MODEL}-{DMAPI_INGRESS_NAME}"
+        container.push(
+            DMAPI_API_PASTE_PATH,
+            self._render_template("api-paste.ini.j2", {"traefik_prefix": traefik_prefix}),
+            make_dirs=True,
+        )
+        logger.info("Wrote %s", DMAPI_API_PASTE_PATH)
 
     def _write_dms_client_config(self, container):
         """Write DMS client config for the trilio-dms client library inside DMAPI.

--- a/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-dm-api-k8s/src/charm.py
@@ -210,6 +210,7 @@ class TrilioDmApiK8sCharm(ops.CharmBase):
             "service_username": creds.get("username"),
             "service_password": creds.get("password"),
             "service_tenant": d.get("service-project-name", "services"),
+            "service_domain_name": d.get("service-domain-name", "Default"),
         }
 
     def _wlm_data(self):
@@ -316,6 +317,7 @@ class TrilioDmApiK8sCharm(ops.CharmBase):
             "keystone_project_name": identity.get("service_tenant", "services"),
             "keystone_username": identity.get("service_username", "dmapi"),
             "keystone_password": identity["service_password"],
+            "service_domain_name": identity.get("service_domain_name", "Default"),
             "cafile": cafile,
         }
         rendered = self._render_template("triliovault-datamover-api.conf.j2", context)

--- a/sunbeam-canonical/charms/trilio-dm-api-k8s/src/templates/api-paste.ini.j2
+++ b/sunbeam-canonical/charms/trilio-dm-api-k8s/src/templates/api-paste.ini.j2
@@ -1,0 +1,57 @@
+###############################################
+# TrilioData, Inc TrilioVault  Data mover API #
+###############################################
+
+[composite:dmapi]
+use = call:dmapi.api.openstack.urlmap:urlmap_factory
+/: dmversions
+/v2: dmapi_v2
+{% if traefik_prefix %}
+{{ traefik_prefix }}: dmversions
+{{ traefik_prefix }}/v2: dmapi_v2
+{% endif %}
+
+[composite:dmapi_v2]
+use = call:dmapi.api.auth:pipeline_factory_v2
+keystone = cors http_proxy_to_wsgi dm_req_id faultwrap request_log sizelimit osprofiler authtoken keystonecontext dmapi_app_v2
+
+[filter:request_log]
+paste.filter_factory = dmapi.api.openstack.requestlog:RequestLog.factory
+
+[filter:dm_req_id]
+paste.filter_factory = dmapi.api.dm_req_id:DmapiReqIdMiddleware.factory
+
+[filter:faultwrap]
+paste.filter_factory = dmapi.api.openstack:FaultWrapper.factory
+
+[filter:osprofiler]
+paste.filter_factory = dmapi.profiler:WsgiMiddleware.factory
+
+[filter:sizelimit]
+paste.filter_factory = oslo_middleware:RequestBodySizeLimiter.factory
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
+
+[app:dmapi_app_v2]
+paste.app_factory = dmapi.api.openstack.dm:APIRouterV2.factory
+
+[pipeline:dmversions]
+pipeline = cors faultwrap request_log http_proxy_to_wsgi dmversionapp
+
+[app:dmversionapp]
+paste.app_factory = dmapi.api.openstack.dm.versions:Versions.factory
+
+##########
+# Shared #
+##########
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = dmapi
+
+[filter:keystonecontext]
+paste.filter_factory = dmapi.api.auth:DmapiKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory

--- a/sunbeam-canonical/charms/trilio-dm-api-k8s/src/templates/triliovault-datamover-api.conf.j2
+++ b/sunbeam-canonical/charms/trilio-dm-api-k8s/src/templates/triliovault-datamover-api.conf.j2
@@ -41,8 +41,8 @@ password = {{ keystone_password }}
 {% else %}insecure = True
 {% endif %}
 signing_dir = /var/cache/dmapi
-project_domain_name = Default
-user_domain_name = Default
+project_domain_name = {{ service_domain_name }}
+user_domain_name = {{ service_domain_name }}
 service_token_roles_required = True
 
 [oslo_messaging_notifications]

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -46,43 +46,6 @@ TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templat
 # wlm-api on startup. The charm overwrites the file with this clean version
 # that removes the deprecated auth fields (keystonemiddleware reads credentials
 # from [keystone_authtoken] in the main config anyway).
-WLM_API_PASTE = """\
-[composite:osapi_workloads]
-use = call:workloadmgr.api:root_app_factory
-/: apiversions
-/v1: openstack_workloads_api_v1
-
-[composite:openstack_workloads_api_v1]
-use = call:workloadmgr.api.middleware.auth:pipeline_factory
-noauth = faultwrap sizelimit noauth apiv1
-keystone = faultwrap sizelimit authtoken keystonecontext apiv1
-keystone_nolimit = faultwrap sizelimit authtoken keystonecontext apiv1
-
-[filter:faultwrap]
-paste.filter_factory = workloadmgr.api.middleware.fault:FaultWrapper.factory
-
-[filter:noauth]
-paste.filter_factory = workloadmgr.api.middleware.auth:NoAuthMiddleware.factory
-
-[filter:sizelimit]
-paste.filter_factory = oslo_middleware.sizelimit:RequestBodySizeLimiter.factory
-
-[app:apiv1]
-paste.app_factory = workloadmgr.api.v1.router:APIRouter.factory
-
-[pipeline:apiversions]
-pipeline = faultwrap osworkloadsversionapp
-
-[app:osworkloadsversionapp]
-paste.app_factory = workloadmgr.api.versions:Versions.factory
-
-[filter:keystonecontext]
-paste.filter_factory = workloadmgr.api.middleware.auth:WorkloadMgrKeystoneContext.factory
-
-[filter:authtoken]
-paste.filter_factory = keystonemiddleware.auth_token:filter_factory
-signing_dir = /var/cache/workloadmgr
-"""
 
 # Port confirmed from `openstack endpoint list` on RHOSO18 (consistent across all
 # OpenStack distributions): triliovault-wlm-internal.svc:8781
@@ -196,6 +159,8 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         )
         # setsid detaches the process from Pebble's controlling terminal so that
         # workloadmgr's cliff/cmd2 cannot open /dev/tty and skips curses init.
+        # --endpoint-type admin uses the admin endpoint URL (http://trilio-wlm-k8s:8781/v1/...)
+        # which routes directly to WLM API without the Traefik path prefix issue.
         cmd = [
             "setsid",
             "workloadmgr",
@@ -206,6 +171,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             "--os-project-name", event.params.get("project-name", "admin"),
             "--os-project-domain-name", event.params.get("project-domain-name", "admin_domain"),
             "--os-region-name", self.config.get("region", "RegionOne"),
+            "--endpoint-type", "admin",
             "trust-create", "--is_cloud_trust", "True", "Admin",
         ]
         try:
@@ -506,7 +472,12 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             make_dirs=True,
         )
         logger.info("Wrote %s", WLM_LOGGING_CONF_PATH)
-        container.push(API_PASTE_PATH, WLM_API_PASTE, make_dirs=True)
+        traefik_prefix = f"/{WLM_INGRESS_MODEL}-{WLM_INGRESS_NAME}"
+        container.push(
+            API_PASTE_PATH,
+            self._render_template("api-paste.ini.j2", {"traefik_prefix": traefik_prefix}),
+            make_dirs=True,
+        )
         logger.info("Wrote %s", API_PASTE_PATH)
 
     def _write_dms_client_config(self, container):

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -355,6 +355,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             "service_username": creds.get("username"),
             "service_password": creds.get("password"),
             "service_tenant": d.get("service-project-name", "services"),
+            "service_domain_name": d.get("service-domain-name", "Default"),
         }
 
     def _get_ca_cert(self):
@@ -461,6 +462,7 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             "keystone_project_name": identity.get("service_tenant", "services"),
             "keystone_username": identity.get("service_username", "wlm"),
             "keystone_password": identity["service_password"],
+            "service_domain_name": identity.get("service_domain_name", "Default"),
             "cafile": cafile,
         }
         rendered = self._render_template("triliovault-wlm.conf.j2", context)

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/templates/api-paste.ini.j2
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/templates/api-paste.ini.j2
@@ -1,0 +1,39 @@
+[composite:osapi_workloads]
+use = call:workloadmgr.api:root_app_factory
+/: apiversions
+/v1: openstack_workloads_api_v1
+{% if traefik_prefix %}
+{{ traefik_prefix }}: apiversions
+{{ traefik_prefix }}/v1: openstack_workloads_api_v1
+{% endif %}
+
+[composite:openstack_workloads_api_v1]
+use = call:workloadmgr.api.middleware.auth:pipeline_factory
+noauth = faultwrap sizelimit noauth apiv1
+keystone = faultwrap sizelimit authtoken keystonecontext apiv1
+keystone_nolimit = faultwrap sizelimit authtoken keystonecontext apiv1
+
+[filter:faultwrap]
+paste.filter_factory = workloadmgr.api.middleware.fault:FaultWrapper.factory
+
+[filter:noauth]
+paste.filter_factory = workloadmgr.api.middleware.auth:NoAuthMiddleware.factory
+
+[filter:sizelimit]
+paste.filter_factory = oslo_middleware.sizelimit:RequestBodySizeLimiter.factory
+
+[app:apiv1]
+paste.app_factory = workloadmgr.api.v1.router:APIRouter.factory
+
+[pipeline:apiversions]
+pipeline = faultwrap osworkloadsversionapp
+
+[app:osworkloadsversionapp]
+paste.app_factory = workloadmgr.api.versions:Versions.factory
+
+[filter:keystonecontext]
+paste.filter_factory = workloadmgr.api.middleware.auth:WorkloadMgrKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+signing_dir = /var/cache/workloadmgr

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/templates/triliovault-wlm.conf.j2
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/templates/triliovault-wlm.conf.j2
@@ -99,8 +99,8 @@ auth_type = password
 username = {{ keystone_username }}
 password = {{ keystone_password }}
 
-user_domain_name = Default
-project_domain_name = Default
+user_domain_name = {{ service_domain_name }}
+project_domain_name = {{ service_domain_name }}
 
 insecure = False
 service_token_roles_required = True


### PR DESCRIPTION
## Summary
- WLM and DMAPI `[keystone_authtoken]` configs had `user_domain_name = Default` and `project_domain_name = Default` hardcoded
- On Sunbeam, keystone-k8s creates service users in `service_domain`, not `Default`
- This caused keystonemiddleware to return 503 "Keystone service temporarily unavailable" on every API request

## Fix
- Read `service-domain-name` from the identity-service relation app databag in both WLM and DMAPI charms
- Pass it as `service_domain_name` to config templates (fallback: `Default` when relation data unavailable)
- Update config templates to use `{{ service_domain_name }}` instead of hardcoded `Default`
- Updated `sunbeam-canonical/CLAUDE.md` with lessons about `receive-ca-cert` relation requirement and service domain

## Test plan
- [ ] `trust-list` via Traefik public endpoint returns 200 (previously 503)
- [ ] `workload-list` via Traefik public endpoint returns 200
- [ ] WLM and DMAPI charms published to Charmhub `latest/candidate` as revision 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)