### PR TITLE
TVAULT-7404: Sunbeam DataMover - nova UID normalization and dataplane bundle fixes

### DIFF
--- a/sunbeam-canonical/CLAUDE.md
+++ b/sunbeam-canonical/CLAUDE.md
@@ -129,6 +129,19 @@ Neither `python3-trilio-dms` nor `tvault-contego` packages ship systemd unit fil
 - `triliovault-dms.service` — runs `trilio-dms-server` as nova user, with `PYTHONPATH=/snap/openstack-hypervisor/current/usr/lib/python3/dist-packages` so it can import nova/kombu from the snap
 - `triliovault-datamover.service` — runs tvault-contego as nova user with the same PYTHONPATH, using `--config-file=/etc/triliovault-datamover/nova.conf` (our patched copy) and `--config-file=/etc/triliovault-datamover/triliovault-datamover.conf`
 
+### Nova user UID normalisation (data plane)
+WLM containers (trilio-wlm-k8s, trilio-dms-k8s) run as `nova` UID 42436. DataMover on compute nodes also runs as `nova` and writes to the same NFS backup target, so both sides must use the same UID.
+
+Sunbeam compute nodes run nova-compute inside the `openstack-hypervisor` snap as **root** — no host-level `nova` user exists. The charm creates one at UID 42436. If a legacy `nova` user exists (e.g. from a `nova-common` deb install at UID 116), the charm:
+- `change-nova-user-id=false` (default): sets `BlockedStatus` with an error message
+- `change-nova-user-id=true`: runs `groupmod`/`usermod` to move nova to UID/GID 42436 and re-owns Trilio directories
+
+**Before `usermod`**: stop Trilio services and then run `systemctl kill --kill-who=all --signal=SIGKILL <service>` for both `triliovault-datamover` and `triliovault-dms`. The `kill --kill-who=all` is required because `s3vaultfuse` (spawned by trilio-dms-server as a child process) can outlive `systemctl stop` and block `usermod` with "user is currently used by process".
+
+The `_ensure_nova_user()` check runs at the **top of `_configure()`** (not only in `_on_install()`). This means every event path — install, config-changed, relation-changed — enforces the check. Setting `change-nova-user-id=true` via `juju config` fires a `config-changed` event which triggers the UID update automatically.
+
+**`nova.conf` re-chown on stale ownership**: `_sync_nova_conf()` normally returns early (no file write) when nova.conf content has not changed. After a nova GID change, this leaves `/etc/triliovault-datamover/nova.conf` with the old GID — unreadable by the `nova` user. Fix: always call `shutil.chown(NOVA_CONF_COPY, user="root", group="nova")` even on the early-return path so ownership is corrected after every `_configure()` call.
+
 ### nova.conf and CA cert handling (data plane)
 The `openstack-hypervisor` snap's nova.conf is at `/var/snap/openstack-hypervisor/common/etc/nova/nova.conf` (root:root 640 — unreadable by the nova user). The charm copies it to `/etc/triliovault-datamover/nova.conf` (root:nova 640).
 

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/charmcraft.yaml
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/charmcraft.yaml
@@ -71,3 +71,20 @@ config:
         Obtain from the WLM pod:
           kubectl exec -n openstack trilio-wlm-k8s-0 -c trilio-wlm -- \
             grep ^connection /etc/triliovault-wlm/triliovault-wlm.conf
+    change-nova-user-id:
+      type: boolean
+      default: false
+      description: |
+        Controls behaviour when a nova user already exists on the compute node with
+        a UID other than 42436 (the standard OpenStack nova UID used by WLM containers
+        and all other OpenStack distributions).
+
+        false (default): Block charm installation with an error message. The operator
+          must either pre-create nova at UID 42436 or set this option to true.
+
+        true: Automatically update the nova user UID/GID to 42436 using usermod/groupmod
+          and re-own Trilio-managed directories. Use this when compute nodes have a
+          legacy nova user created by the nova-common deb package (typically UID 116).
+
+        If nova user does not exist at all, it is always created at UID 42436 regardless
+        of this setting.

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/charmcraft.yaml
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/charmcraft.yaml
@@ -50,7 +50,7 @@ config:
   options:
     triliovault-pkg-source:
       type: string
-      default: "deb [trusted=yes] https://apt.trilio.io jammy main"
+      default: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       description: APT repository line for TrilioVault packages
     trilio-version:
       type: string

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -157,18 +157,6 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         self.unit.status = ops.WaitingStatus("Waiting for amqp and identity-credentials relations")
 
     def _on_config_changed(self, event):
-        # Re-run nova UID check on every config change so that flipping
-        # change-nova-user-id=true immediately triggers the UID update without
-        # needing a separate upgrade-charm.
-        try:
-            self._ensure_nova_user()
-        except RuntimeError as e:
-            logger.error("Nova user UID conflict: %s", e)
-            self.unit.status = ops.BlockedStatus(str(e))
-            return
-        except subprocess.CalledProcessError as e:
-            self.unit.status = ops.BlockedStatus(f"Nova user setup failed: {e}")
-            return
         self._configure(event)
 
     def _on_upgrade_charm(self, event):
@@ -240,6 +228,19 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
     # --- core configure logic ---
 
     def _configure(self, event):
+        # Nova UID check runs on every configure path (install, relation-changed,
+        # config-changed) so no event can override a BlockedStatus set by install.
+        # _ensure_nova_user() is a fast no-op when nova is already at 42436.
+        try:
+            self._ensure_nova_user()
+        except RuntimeError as e:
+            logger.error("Nova user UID conflict: %s", e)
+            self.unit.status = ops.BlockedStatus(str(e))
+            return
+        except subprocess.CalledProcessError as e:
+            self.unit.status = ops.BlockedStatus(f"Nova user setup failed: {e}")
+            return
+
         missing = self._missing_relations()
         if missing:
             self.unit.status = ops.WaitingStatus(f"Waiting for: {', '.join(missing)}")

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -434,6 +434,10 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
                     check=True,
                 )
                 old_gid = None
+            # Stop Trilio services before usermod — usermod refuses to change
+            # UID while the user has running processes (tvault-contego, trilio-dms-server).
+            for svc in (DATAMOVER_SERVICE, DMS_SERVICE):
+                subprocess.run(["systemctl", "stop", svc], check=False)
             # Update nova user UID
             subprocess.run(
                 ["usermod", "--uid", str(NOVA_TARGET_UID),

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -157,6 +157,18 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         self.unit.status = ops.WaitingStatus("Waiting for amqp and identity-credentials relations")
 
     def _on_config_changed(self, event):
+        # Re-run nova UID check on every config change so that flipping
+        # change-nova-user-id=true immediately triggers the UID update without
+        # needing a separate upgrade-charm.
+        try:
+            self._ensure_nova_user()
+        except RuntimeError as e:
+            logger.error("Nova user UID conflict: %s", e)
+            self.unit.status = ops.BlockedStatus(str(e))
+            return
+        except subprocess.CalledProcessError as e:
+            self.unit.status = ops.BlockedStatus(f"Nova user setup failed: {e}")
+            return
         self._configure(event)
 
     def _on_upgrade_charm(self, event):

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -708,6 +708,10 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             old_hash = None
 
         if new_hash == old_hash:
+            # Content unchanged — still fix ownership in case nova GID changed
+            if os.path.exists(NOVA_CONF_COPY):
+                shutil.chown(NOVA_CONF_COPY, user="root", group="nova")
+                os.chmod(NOVA_CONF_COPY, 0o640)
             return False
 
         os.makedirs(os.path.dirname(NOVA_CONF_COPY), exist_ok=True)

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -19,9 +19,11 @@ and every compute node (this charm). The two instances communicate via RabbitMQ
 and handle NFS / S3 mount operations on their respective hosts.
 """
 
+import grp as _grp
 import hashlib
 import json
 import jinja2
+import pwd
 import re
 import logging
 import os
@@ -56,6 +58,7 @@ DMS_LOG_FILE = "/var/log/triliovault/trilio-dms-server.log"
 DMS_CLIENT_LOG_FILE = "/var/log/triliovault/trilio-dms-client.log"
 TRILIO_LIST_PATH = "/etc/apt/sources.list.d/trilio.list"
 TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+NOVA_TARGET_UID = 42436  # Standard OpenStack nova UID (Kolla, UCA, WLM container all use this)
 
 # Systemd unit for the DMS server on compute nodes.
 # python3-trilio-dms is designed for kolla (container); it ships no systemd unit.
@@ -142,6 +145,11 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             self._write_nova_sudoers()
             self._install_rootwrap_filters()
             self._write_systemd_services()
+        except RuntimeError as e:
+            # Nova UID conflict — operator must set change-nova-user-id=true or fix manually
+            logger.error("Nova user UID conflict: %s", e)
+            self.unit.status = ops.BlockedStatus(str(e))
+            return
         except subprocess.CalledProcessError as e:
             logger.error("Package install failed: %s", e)
             self.unit.status = ops.BlockedStatus(f"Package install failed: {e}")
@@ -165,6 +173,10 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             self._write_nova_sudoers()
             self._install_rootwrap_filters()
             self._write_systemd_services()
+        except RuntimeError as e:
+            logger.error("Nova user UID conflict: %s", e)
+            self.unit.status = ops.BlockedStatus(str(e))
+            return
         except subprocess.CalledProcessError as e:
             self.unit.status = ops.BlockedStatus(f"Upgrade failed: {e}")
             return
@@ -339,27 +351,109 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         logger.info("Trilio apt repo configured")
 
     def _ensure_nova_user(self):
-        """Create nova system user/group if absent, then add to disk and kvm groups.
+        """Create or normalize nova user to UID 42436.
 
-        python3-tvault-contego postinst runs usermod for nova. On Sunbeam compute
-        nodes nova-compute runs inside the openstack-hypervisor snap and no host-level
-        nova user is created by the snap, so the postinst fails without this.
-        nova needs disk+kvm group membership for libvirt/QEMU operations (mirrors
-        the kolla Dockerfile: usermod -aG disk,kvm nova).
+        Sunbeam compute nodes run nova-compute inside the openstack-hypervisor snap,
+        so no host-level nova user exists. If a legacy nova user exists (e.g. from
+        a nova-common deb install) with a different UID, the charm blocks by default
+        to avoid unintended system changes.  Set change-nova-user-id=true to allow
+        the UID update.  Both WLM containers and DataMover must use the same nova UID
+        (42436) to read/write the same NFS backup target.
+
+        Three cases:
+          1. nova user does not exist  → create fresh at UID 42436
+          2. nova user exists at 42436 → nothing to do
+          3. nova user exists at other UID:
+               change-nova-user-id=false → raise RuntimeError (blocks install)
+               change-nova-user-id=true  → update UID/GID, re-own nova-owned files
         """
         try:
-            subprocess.run(["getent", "passwd", "nova"], check=True,
-                           capture_output=True)
-        except subprocess.CalledProcessError:
-            subprocess.run(["addgroup", "--system", "nova"], check=False)
+            pw = pwd.getpwnam("nova")
+            current_uid = pw.pw_uid
+        except KeyError:
+            current_uid = None
+
+        if current_uid is None:
+            # Case 1: nova does not exist — create fresh at the correct UID
+            try:
+                _grp.getgrnam("nova")
+            except KeyError:
+                subprocess.run(
+                    ["groupadd", "--system", "--gid", str(NOVA_TARGET_UID), "nova"],
+                    check=False,  # ignore if GID is taken; fallback to system-assigned GID
+                )
             subprocess.run(
-                ["adduser", "--system", "--no-create-home",
-                 "--ingroup", "nova", "nova"],
+                ["useradd", "--system", "--no-create-home",
+                 "--uid", str(NOVA_TARGET_UID), "--gid", "nova",
+                 "--shell", "/usr/sbin/nologin", "nova"],
                 check=True,
             )
-            logger.info("Created system user nova")
-        for grp in ("disk", "kvm"):
-            subprocess.run(["usermod", "-aG", grp, "nova"], check=False)
+            logger.info("Created nova user at UID %d", NOVA_TARGET_UID)
+
+        elif current_uid == NOVA_TARGET_UID:
+            # Case 2: already correct
+            logger.info("nova user already at UID %d — no change needed", NOVA_TARGET_UID)
+
+        else:
+            # Case 3: nova exists but has a different UID
+            if not self.config.get("change-nova-user-id"):
+                raise RuntimeError(
+                    f"nova user exists with UID {current_uid} but UID {NOVA_TARGET_UID} is "
+                    f"required (WLM containers use {NOVA_TARGET_UID} for NFS access). "
+                    f"Set change-nova-user-id=true to allow automatic UID update, "
+                    f"or recreate nova at UID {NOVA_TARGET_UID} manually before deploying."
+                )
+            logger.info(
+                "change-nova-user-id=true: updating nova from UID %d to %d",
+                current_uid, NOVA_TARGET_UID,
+            )
+            # Update nova group GID first (usermod -g requires the group to exist at new GID)
+            try:
+                nova_grp = _grp.getgrnam("nova")
+                old_gid = nova_grp.gr_gid
+                if old_gid != NOVA_TARGET_UID:
+                    subprocess.run(
+                        ["groupmod", "--gid", str(NOVA_TARGET_UID), "nova"],
+                        check=True,
+                    )
+            except KeyError:
+                subprocess.run(
+                    ["groupadd", "--system", "--gid", str(NOVA_TARGET_UID), "nova"],
+                    check=True,
+                )
+                old_gid = None
+            # Update nova user UID
+            subprocess.run(
+                ["usermod", "--uid", str(NOVA_TARGET_UID),
+                 "--gid", str(NOVA_TARGET_UID), "nova"],
+                check=True,
+            )
+            # Re-own files in Trilio directories that were previously owned by old UID/GID.
+            # We scope to known Trilio directories rather than running find / (too expensive).
+            re_own_dirs = [
+                "/etc/triliovault-datamover", "/etc/triliovault-dms",
+                "/etc/triliovault-object-store",
+                "/var/log/triliovault", "/var/triliovault-mounts",
+                "/var/triliovault", "/opt/triliovault",
+            ]
+            for d in re_own_dirs:
+                if os.path.exists(d):
+                    subprocess.run(
+                        ["find", d, "-user", str(current_uid),
+                         "-exec", "chown", "nova:nova", "{}", "+"],
+                        check=False,
+                    )
+                    if old_gid is not None:
+                        subprocess.run(
+                            ["find", d, "-group", str(old_gid),
+                             "-exec", "chgrp", "nova", "{}", "+"],
+                            check=False,
+                        )
+            logger.info("Updated nova to UID %d and re-owned Trilio directories", NOVA_TARGET_UID)
+
+        # Always ensure disk and kvm group membership (needed for QEMU/libvirt operations)
+        for grp_name in ("disk", "kvm"):
+            subprocess.run(["usermod", "-aG", grp_name, "nova"], check=False)
 
     def _install_packages(self):
         version = self.config["trilio-version"].strip()

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -31,7 +31,6 @@ import pathlib
 import shutil
 import socket
 import subprocess
-import time
 
 import ops
 
@@ -436,15 +435,15 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
                     check=True,
                 )
                 old_gid = None
-            # Stop Trilio services before usermod — usermod refuses to change
-            # UID while the user has running processes (tvault-contego, trilio-dms-server).
+            # Stop Trilio services before usermod — usermod refuses to change UID
+            # while the user has running processes.  stop() + kill(all) ensures
+            # all cgroup members (including s3vaultfuse children) are terminated.
             for svc in (DATAMOVER_SERVICE, DMS_SERVICE):
                 subprocess.run(["systemctl", "stop", svc], check=False)
-            # Kill any nova processes that outlived the services (e.g. s3vaultfuse
-            # spawned as a child of trilio-dms that stays running after systemctl stop).
-            subprocess.run(["pkill", "--signal", "TERM", "-u", "nova"], check=False)
-            time.sleep(3)
-            subprocess.run(["pkill", "--signal", "KILL", "-u", "nova"], check=False)
+                subprocess.run(
+                    ["systemctl", "kill", "--kill-who=all", "--signal=SIGKILL", svc],
+                    check=False,
+                )
             # Update nova user UID
             subprocess.run(
                 ["usermod", "--uid", str(NOVA_TARGET_UID),

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -31,6 +31,7 @@ import pathlib
 import shutil
 import socket
 import subprocess
+import time
 
 import ops
 
@@ -439,6 +440,11 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             # UID while the user has running processes (tvault-contego, trilio-dms-server).
             for svc in (DATAMOVER_SERVICE, DMS_SERVICE):
                 subprocess.run(["systemctl", "stop", svc], check=False)
+            # Kill any nova processes that outlived the services (e.g. s3vaultfuse
+            # spawned as a child of trilio-dms that stays running after systemctl stop).
+            subprocess.run(["pkill", "--signal", "TERM", "-u", "nova"], check=False)
+            time.sleep(3)
+            subprocess.run(["pkill", "--signal", "KILL", "-u", "nova"], check=False)
             # Update nova user UID
             subprocess.run(
                 ["usermod", "--uid", str(NOVA_TARGET_UID),

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -9,21 +9,23 @@
 #   juju switch openstack-machines
 #   juju deploy ./trilio-dataplane-bundle.yaml
 #
-# Cross-model SAAS relations pull amqp and keystone-credentials from the
-# openstack model.  Offer those relations first if not already offered:
-#   juju switch openstack
-#   juju offer rabbitmq:amqp
-#   juju offer keystone:identity-credentials
-#   juju switch openstack-machines
+# Cross-model SAAS offers are declared in the saas: section below.
+# Find the correct offer URLs for your deployment with:
+#   juju find-offers --format=tabular
+# Update the saas: urls to match your controller name (default: sunbeam-controller).
 
-bundle: machine
+saas:
+  rabbitmq:
+    url: sunbeam-controller:controller0/openstack.rabbitmq
+  keystone-credentials:
+    url: sunbeam-controller:controller0/openstack.keystone-credentials
 
 applications:
 
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
     channel: latest/candidate
-    revision: 2
+    revision: 4
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"
@@ -33,10 +35,6 @@ applications:
 relations:
   # Subordinate binding to the compute principal
   - [trilio-data-mover:juju-info, openstack-hypervisor:juju-info]
-
-  # Cross-model SAAS relations.
-  # IMPORTANT: Replace "admin" with your actual Juju controller name.
-  # Find it with: juju controllers --format=tabular | grep '*'
-  # Replace "openstack" if you used a different name for the k8s model.
-  - [trilio-data-mover:amqp, admin/openstack.rabbitmq:amqp]
-  - [trilio-data-mover:identity-credentials, admin/openstack.keystone:identity-credentials]
+  # Cross-model relations via saas: aliases above
+  - [trilio-data-mover:amqp, rabbitmq:amqp]
+  - [trilio-data-mover:identity-credentials, keystone-credentials:identity-credentials]

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -31,7 +31,7 @@ applications:
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
     channel: latest/candidate
-    revision: 4
+    revision: 5
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -28,6 +28,7 @@ applications:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.trilio.io jammy main"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"
       debug: false
+      change-nova-user-id: false  # Set true only if compute nodes have a legacy nova user at wrong UID
 
 relations:
   # Subordinate binding to the compute principal

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -25,7 +25,7 @@ applications:
     channel: latest/candidate
     revision: 2
     options:
-      triliovault-pkg-source: "deb [trusted=yes] https://apt.trilio.io jammy main"
+      triliovault-pkg-source: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"
       debug: false
       change-nova-user-id: false  # Set true only if compute nodes have a legacy nova user at wrong UID

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -31,7 +31,7 @@ applications:
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
     channel: latest/candidate
-    revision: 6
+    revision: 7
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -31,7 +31,7 @@ applications:
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
     channel: latest/candidate
-    revision: 5
+    revision: 6
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -22,6 +22,12 @@ saas:
 
 applications:
 
+  # Reference entry for the existing principal — not redeployed by this bundle.
+  # Juju requires all relation endpoints to be declared even for pre-existing apps.
+  openstack-hypervisor:
+    charm: openstack-hypervisor
+    channel: 2024.1/stable
+
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
     channel: latest/candidate


### PR DESCRIPTION
## Summary

- **Nova UID normalization** (`_ensure_nova_user()`): Sunbeam compute nodes have no host-level `nova` user. The charm now creates it at UID 42436 (standard OpenStack nova UID used by WLM containers). If a legacy `nova` user exists at a different UID:
  - `change-nova-user-id=false` (default): charm blocks with a clear error message
  - `change-nova-user-id=true`: updates UID/GID via `usermod`/`groupmod`, re-owns Trilio directories. Uses `systemctl kill --kill-who=all --signal=SIGKILL` before `usermod` to terminate any service cgroup members (e.g. `s3vaultfuse` spawned by `triliovault-dms`) that would block `usermod`.
- **`change-nova-user-id` config option** added to `charmcraft.yaml` and `trilio-dataplane-bundle.yaml` (default `false`)
- **Nova UID check in `_configure()`**: moved to the top of `_configure()` so every event path (install, config-changed, relation-changed) enforces the check — a config flip to `true` triggers the UID update on the next `config-changed` event
- **`triliovault-pkg-source` default** updated to `deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /`
- **Dataplane bundle fixes** for Juju 3.x:
  - Added `saas:` section for cross-model RabbitMQ and Keystone relations
  - Removed invalid `bundle: machine` declaration
  - Added `openstack-hypervisor` reference entry (required for relation validation)
  - Bundle deploys cleanly with `juju deploy ./trilio-dataplane-bundle.yaml` — no separate `juju relate` commands needed
- DataMover charm published as r6 to `latest/candidate` on Charmhub

## Test plan

- [ ] Deploy dataplane bundle on fresh Sunbeam cluster — verify `trilio-data-mover` reaches `active`
- [ ] Set nova UID to a wrong value on a compute node, deploy with `change-nova-user-id=false` — verify `blocked` status with correct message
- [ ] Set `juju config trilio-data-mover change-nova-user-id=true` — verify unit recovers to `active` automatically
- [ ] Verify both compute nodes show `DataMover and DMS running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)