### PR TITLE
TVAULT-7404: Sunbeam Canonical OpenStack native Juju charm implementation

### DIFF
--- a/sunbeam-canonical/CLAUDE.md
+++ b/sunbeam-canonical/CLAUDE.md
@@ -98,6 +98,19 @@ Additionally:
 - `log_config_append = <path>` points to the per-service Python logging conf pushed by the charm
 - Log formatter classes: `workloadmgr.openstack.common.log.UTCFormatter`, `dmapi.common.log.UTCFormatter`, `contego.common.log.UTCFormatter`, `s3fuse.log.UTCFormatter`
 
+### workloadmgr CLI for testing — run from inside the WLM pod
+When running `workloadmgr` commands for testing (e.g. `workload-create`, `workload-list`, `snapshot-create`, `snapshot-list`, `snapshot-show`), run them from **inside** the `trilio-wlm` container of any WLM pod, not from external nodes or from the build server. The external nodes lack the `workloadmgrclient` openstack plugin. The `openstack workload ...` CLI extension is only available inside the pod.
+
+```bash
+kubectl exec -n openstack trilio-wlm-k8s-0 -c trilio-wlm -- \
+  setsid workloadmgr --os-auth-url http://10.152.183.175:5000/v3 \
+    --os-username svc_trilio_wlm_k8s-... --os-password ... \
+    --os-project-name services --os-user-domain-name service_domain \
+    --os-project-domain-name service_domain snapshot-list
+```
+
+Or export the auth env vars inside the pod first and then run `workloadmgr <subcommand>`. The `setsid` prefix is required (see note below).
+
 ### workloadmgr CLI in Pebble exec — setsid required
 When the WLM charm runs `workloadmgr` via `container.exec()` (Pebble), the process inherits Pebble's controlling terminal (the container's `/dev/console`). `workloadmgr`'s cliff/cmd2 layer opens `/dev/tty` and calls `curses.cbreak()`, which fails on the container console with "cbreak() returned ERR".
 
@@ -126,8 +139,10 @@ Only ONE instance of `wlm-cron` must run cluster-wide. The charm enforces this b
 
 ### DMS systemd units (data plane)
 Neither `python3-trilio-dms` nor `tvault-contego` packages ship systemd unit files (both were designed for kolla containers). The `trilio-data-mover` charm writes both units to `/lib/systemd/system/` during install:
-- `triliovault-dms.service` — runs `trilio-dms-server` as nova user, with `PYTHONPATH=/snap/openstack-hypervisor/current/usr/lib/python3/dist-packages` so it can import nova/kombu from the snap
-- `triliovault-datamover.service` — runs tvault-contego as nova user with the same PYTHONPATH, using `--config-file=/etc/triliovault-datamover/nova.conf` (our patched copy) and `--config-file=/etc/triliovault-datamover/triliovault-datamover.conf`
+- `triliovault-dms.service` — runs `trilio-dms-server` as root, with `PYTHONPATH=/snap/openstack-hypervisor/current/usr/lib/python3/dist-packages` so it can import nova/kombu from the snap
+- `triliovault-datamover.service` — runs tvault-contego as root with the same PYTHONPATH, using `--config-file=/etc/triliovault-datamover/nova.conf` (our patched copy) and `--config-file=/etc/triliovault-datamover/triliovault-datamover.conf`
+
+**`StartLimitIntervalSec=0` is required in both unit `[Unit]` sections.** The systemd default allows only 5 starts in 10 seconds; an earlier version had an explicit `StartLimitIntervalSec=120 / StartLimitBurst=3` limit. When the DataMover crashes quickly due to transient issues (e.g. RabbitMQ `ACCESS_REFUSED` errors during credential rotation), the rapid restart cycle exhausts the limit and the unit enters `start-limit-hit` state (`systemctl status triliovault-datamover.service` shows `Result: start-limit-hit`). Once in that state, `systemctl start` immediately returns an error — the charm's own restart calls silently do nothing, leaving the DataMover permanently down even after the underlying issue is resolved. Setting `StartLimitIntervalSec=0` disables the limit entirely so the service always retries. If a compute node gets stuck in `start-limit-hit` on an older charm revision, recover with: `sudo systemctl reset-failed triliovault-datamover.service && sudo systemctl reset-failed triliovault-dms.service`, then trigger a charm hook re-run.
 
 ### Nova user UID normalisation (data plane)
 WLM containers (trilio-wlm-k8s, trilio-dms-k8s) run as `nova` UID 42436. DataMover on compute nodes also runs as `nova` and writes to the same NFS backup target, so both sides must use the same UID.
@@ -396,7 +411,7 @@ All four charms are registered on Charmhub under the `triliodata` publisher:
 | DMS k8s | k8s | `trilio-dms-k8s` |
 | DataMover machine | subordinate | `trilio-data-mover-sunbeam` |
 
-Publish channel: **`latest/candidate`**
+Publish channel: **`6.2/candidate`**
 
 Build and publish workflow:
 ```bash
@@ -407,7 +422,108 @@ charmcraft pack
 # Upload and release
 charmcraft upload <charm>.charm --name <charm-name>
 # Note the revision number from upload output, then:
-charmcraft release <charm-name> --revision <N> --channel latest/candidate
+charmcraft release <charm-name> --revision <N> --channel 6.2/candidate
 ```
 
 > **Note:** `charmcraft login` requires a browser on first use. Run `charmcraft login --export creds.txt` locally, transfer `creds.txt` to the server, then `export CHARMCRAFT_AUTH=$(cat creds.txt)` before building.
+
+#### `build-packages: [git]` required in charmcraft.yaml
+charmcraft's LXD build container does not include `git` by default. Any charm whose `requirements.txt` has a `git+https://` dependency will fail during `charmcraft pack` with:
+```
+ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version
+```
+Fix: add `build-packages: [git]` under the `parts.charm` section of `charmcraft.yaml`. This is already in `trilio-data-mover-sunbeam/charmcraft.yaml` — every charm with git-URL pip deps needs it.
+
+#### LXD zombie container blocks subsequent `charmcraft pack`
+If a previous `charmcraft pack` invocation was killed or backgrounded and left behind a stopped LXD container, the next pack attempt fails with:
+```
+Error: The device already exists
+```
+Check for stopped containers: `lxc list | grep charmcraft`. If the container is `STOPPED` (not `RUNNING`), wait a moment and retry — charmcraft will reuse or clean it up. If it is `RUNNING` from a background job, wait for it to finish before starting a new pack.
+
+#### Deploying bundles — use `./` path and `--trust`
+`juju deploy` does NOT accept an absolute path outside the current directory for bundle YAML files:
+- **Wrong**: `juju deploy /tmp/trilio-ctlplane-bundle.yaml` → "no charm was found"
+- **Correct**: copy the bundle to the working directory and deploy with `./`: `juju deploy ./trilio-ctlplane-bundle.yaml`
+
+Both control-plane bundles require `--trust` because the WLM and DMAPI charms patch their own StatefulSets at runtime via the Kubernetes API (FUSE device access, shared vault-mounts volume):
+```bash
+juju switch openstack
+juju deploy ./trilio-ctlplane-bundle.yaml --trust
+
+juju switch openstack-machines
+juju deploy ./trilio-dataplane-bundle.yaml
+# (data plane bundle does NOT need --trust)
+```
+
+Also strip CRLF from bundle files copied from the Windows working tree before deploying — see the "Windows-checkout file sync" note above.
+
+---
+
+## Testing
+
+### Fresh reinstall procedure (clean slate)
+When a fresh reinstall is needed (e.g. to pick up new charm revisions or reset corrupt state), follow this order:
+
+```bash
+# 1. Remove control plane applications (--destroy-storage drops MySQL databases too)
+juju switch openstack
+juju remove-application trilio-wlm-k8s trilio-dm-api-k8s --destroy-storage
+
+# Wait until pods are fully terminated
+kubectl get pods -n openstack | grep trilio   # expect: no output
+
+# 2. Remove data plane
+juju switch openstack-machines
+juju remove-application trilio-data-mover
+
+# Wait until subordinate units are gone
+juju status trilio-data-mover   # expect: "not found"
+
+# 3. Verify MySQL databases are gone (--destroy-storage above should handle this,
+#    but verify if re-deploy gets a "database already exists" error)
+kubectl exec -n openstack mysql-k8s-0 -c mysql -- \
+  mysql -u root -p$(kubectl get secret -n openstack mysql-k8s-app -o jsonpath='{.data.root-password}' | base64 -d) \
+  -e "SHOW DATABASES;" | grep -E 'workloadmgr|dmapi'
+# If databases still exist, drop them:
+# DROP DATABASE workloadmgr; DROP DATABASE dmapi;
+
+# 4. Deploy fresh
+juju switch openstack
+juju deploy ./trilio-ctlplane-bundle.yaml --trust
+
+juju switch openstack-machines
+juju deploy ./trilio-dataplane-bundle.yaml
+
+# 5. Wait for active, then attach license and create trust
+juju switch openstack
+juju wait-for application trilio-wlm-k8s --query='status=="active"' --timeout=15m
+juju attach-resource trilio-wlm-k8s license=<path-to-license>
+juju run trilio-wlm-k8s/leader create-cloud-admin-trust password=<admin-password>
+```
+
+### workloadmgr test scope — admin credentials required
+`workloadmgr workload-list` and `snapshot-list` are scoped to the authenticated user's project. If workloads were created using admin credentials (project=`admin`), the service account credentials (project=`services`) will return an empty list. Always use the same credentials (project scope) that were used to create the workload:
+
+```bash
+# Inside the WLM pod — use admin project scope, not service account
+kubectl exec -n openstack trilio-wlm-k8s-0 -c trilio-wlm -- \
+  setsid workloadmgr \
+    --os-auth-url http://<keystone-clusterip>:5000/v3 \
+    --os-username admin \
+    --os-password <admin-password> \
+    --os-project-name admin \
+    --os-user-domain-name admin_domain \
+    --os-project-domain-name admin_domain \
+    workload-list
+```
+
+The `setsid` prefix is required — see the "workloadmgr CLI in Pebble exec" section above.
+
+### Snapshot verification test flow
+After fresh install and license/trust setup:
+1. Create backup target (NFS or S3) via the test script: `sunbeam-canonical/test/01_create_backup_targets.sh`
+2. Create a test workload (one VM): run `workloadmgr workload-create` from inside the WLM pod
+3. Trigger a snapshot: `workloadmgr snapshot-create <workload-id>`
+4. Poll status: `workloadmgr snapshot-show <snapshot-id>` until `available` (success) or `error`
+5. On error: check WLM logs (`kubectl logs -n openstack trilio-wlm-k8s-0 -c trilio-wlm`) and DataMover logs on compute nodes (`journalctl -u triliovault-datamover`)

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/charmcraft.yaml
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/charmcraft.yaml
@@ -28,6 +28,8 @@ parts:
   charm:
     plugin: charm
     source: .
+    build-packages:
+      - git
 
 requires:
   juju-info:

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -258,7 +258,14 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         resolvable from compute nodes outside the k8s cluster.
         """
         if self.unit.is_leader():
-            event.relation.data[self.app]["username"] = "dmapi"
+            # Use username "contego" (not "dmapi") to avoid a password conflict.
+            # Both DMAPI and this DataMover need the dmapi vhost, but
+            # rabbitmq-k8s generates an independent password per relation —
+            # two relations requesting the same username cause each other's
+            # password to be overwritten in RabbitMQ, leaving one service
+            # with stale credentials. Using a distinct username per consumer
+            # means each has its own stable password while sharing the vhost.
+            event.relation.data[self.app]["username"] = "contego"
             event.relation.data[self.app]["vhost"] = "dmapi"
             event.relation.data[self.app]["external_connectivity"] = json.dumps(True)
 
@@ -277,7 +284,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
             return
         amqp_rel = self.model.get_relation("amqp")
         if amqp_rel:
-            amqp_rel.data[self.app]["username"] = "dmapi"
+            amqp_rel.data[self.app]["username"] = "contego"
             amqp_rel.data[self.app]["vhost"] = "dmapi"
             amqp_rel.data[self.app]["external_connectivity"] = json.dumps(True)
         identity_rel = self.model.get_relation("identity-credentials")
@@ -615,7 +622,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
     def _write_datamover_config(self):
         amqp = self._amqp_data()
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://{amqp.get('username', 'contego')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
             f"/{amqp.get('vhost', 'dmapi')}"
         )
@@ -643,7 +650,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
         identity = self._identity_data()
 
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://{amqp.get('username', 'contego')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
             f"/{amqp.get('vhost', 'dmapi')}"
         )
@@ -683,7 +690,7 @@ class TrilioDataMoverSunbeamCharm(ops.CharmBase):
 
         amqp = self._amqp_data()
         transport_url = (
-            f"rabbit://{amqp.get('username', 'dmapi')}:{amqp['password']}"
+            f"rabbit://{amqp.get('username', 'contego')}:{amqp['password']}"
             f"@{amqp['host']}:{amqp.get('port', '5672')}"
             f"/{amqp.get('vhost', 'dmapi')}"
         )

--- a/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-data-mover-sunbeam/src/charm.py
@@ -95,6 +95,7 @@ DMS_SYSTEMD_UNIT = """\
 [Unit]
 Description=TrilioVault Dynamic Mount Service
 After=network.target
+StartLimitIntervalSec=0
 
 [Service]
 # TVAULT-7404 root-user experiment (see nova-user-known-good-state.md for
@@ -121,8 +122,7 @@ DATAMOVER_SYSTEMD_UNIT = """\
 [Unit]
 Description=TrilioVault DataMover (tvault-contego)
 After=network.target
-StartLimitIntervalSec=120
-StartLimitBurst=3
+StartLimitIntervalSec=0
 
 [Service]
 # TVAULT-7404 root-user experiment (see nova-user-known-good-state.md for

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -29,6 +29,7 @@ Relation interface notes (Sunbeam Caracal):
     Requirer writes a JSON blob under "data" key in the app databag.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -888,6 +889,16 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         # NFS/permission issues more simply than matching UIDs everywhere.
         cmd_base = f"/usr/bin/{{}} --config-file {CONFIG_PATH}"
         env = self._get_ca_bundle_env()
+        # Include a fingerprint of the AMQP password in every service's environment.
+        # Pebble only restarts a service when its layer plan (command + environment)
+        # changes — a config-file-only update is invisible to replan(). By stamping
+        # the password hash here, any AMQP credential rotation automatically causes
+        # replan() to restart all WLM services and pick up the new transport_url.
+        amqp = self._amqp_data()
+        if amqp:
+            env["WLM_CONFIG_FINGERPRINT"] = hashlib.sha256(
+                amqp.get("password", "").encode()
+            ).hexdigest()[:12]
         services = {
             "wlm-api": {
                 "override": "replace",

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -365,8 +365,6 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             missing.append("database")
         if not self._amqp_data():
             missing.append("amqp")
-        if not self._amqp_dms_data():
-            missing.append("amqp-dms")
         if not self._identity_data():
             missing.append("identity-service")
         return missing
@@ -759,13 +757,16 @@ class TrilioWlmK8sCharm(ops.CharmBase):
     def _write_dms_client_config(self, container):
         """Write DMS client config for the trilio-dms client library inside WLM.
 
-        Db url is WLM's own database (not DMAPI's). RabbitMQ uses the
-        *workloadmgr* vhost (amqp-dms relation) — same as WLM's own transport,
-        matching RHOSO18 pattern where WLM-side DMS uses the workloadmgr vhost.
+        Db url is WLM's own database (not DMAPI's). RabbitMQ uses the main
+        *amqp* relation credentials (same workloadmgr user/vhost as WLM's
+        oslo.messaging transport_url). Using the same relation avoids a
+        password conflict that occurs when two relations request the same
+        RabbitMQ username — rabbitmq-k8s generates independent passwords per
+        relation, but a single RabbitMQ user can only have one active password.
         node_id targets this unit's own embedded DMS server (see _dms_node_id).
         Written once — all four WLM services share the same container filesystem.
         """
-        amqp_dms = self._amqp_dms_data()
+        amqp_dms = self._amqp_data()
         db = self._db_data()
 
         endpoint = db["endpoints"].split(",")[0].strip()
@@ -794,13 +795,20 @@ class TrilioWlmK8sCharm(ops.CharmBase):
     def _write_dms_server_config(self, container):
         """Write server.conf for the embedded DMS server in the trilio-dms container.
 
-        Reuses WLM's own already-computed Keystone auth_url and CA cert
+        Uses the main *amqp* relation credentials (same workloadmgr user/vhost
+        as WLM's oslo.messaging transport_url). Two relations requesting the same
+        RabbitMQ username get different passwords from rabbitmq-k8s, causing an
+        auth failure for whichever relation's password was overwritten last. Using
+        the same single amqp relation for both transport_url and DMS configs
+        avoids this conflict entirely.
+
+        Also reuses WLM's own already-computed Keystone auth_url and CA cert
         (this unit's own identity-service/receive-ca-cert relation data)
         rather than a separate config option — the embedded server only ever
         serves this one co-located WLM unit, so there's nothing to configure
         independently.
         """
-        amqp_dms = self._amqp_dms_data()
+        amqp_dms = self._amqp_data()
         identity = self._identity_data()
         rabbitmq_url = (
             f"rabbit://{amqp_dms.get('username', 'workloadmgr')}:{amqp_dms['password']}"

--- a/sunbeam-canonical/trilio-ctlplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-ctlplane-bundle.yaml
@@ -61,7 +61,7 @@ applications:
   trilio-wlm-k8s:
     charm: trilio-wlm-k8s
     channel: 6.2/candidate
-    revision: 13
+    revision: 14
     scale: 3
     trust: true
     options:

--- a/sunbeam-canonical/trilio-ctlplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-ctlplane-bundle.yaml
@@ -61,7 +61,7 @@ applications:
   trilio-wlm-k8s:
     charm: trilio-wlm-k8s
     channel: 6.2/candidate
-    revision: 12
+    revision: 13
     scale: 3
     trust: true
     options:
@@ -82,9 +82,10 @@ relations:
   # WLM relations
   - [trilio-wlm-k8s:database, mysql:database]
   - [trilio-wlm-k8s:amqp, rabbitmq:amqp]
-  # WLM's embedded DMS server needs the *dmapi* vhost, not WLM's own `wlm`
-  # vhost — see trilio-wlm-k8s/src/charm.py _write_dms_server_config.
-  - [trilio-wlm-k8s:amqp-dms, rabbitmq:amqp]
+  # NOTE: amqp-dms relation is intentionally absent. WLM's DMS client and embedded
+  # DMS server both use the main amqp relation credentials (workloadmgr/workloadmgr).
+  # Two separate relations requesting the same RabbitMQ username would get different
+  # passwords from rabbitmq-k8s, causing an auth failure for one of them.
   - [trilio-wlm-k8s:identity-service, keystone:identity-service]
   - [trilio-wlm-k8s:ingress-internal, traefik:ingress]
   - [trilio-wlm-k8s:ingress-public, traefik-public:ingress]

--- a/sunbeam-canonical/trilio-ctlplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-ctlplane-bundle.yaml
@@ -61,7 +61,7 @@ applications:
   trilio-wlm-k8s:
     charm: trilio-wlm-k8s
     channel: 6.2/candidate
-    revision: 14
+    revision: 15
     scale: 3
     trust: true
     options:

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -51,7 +51,7 @@ applications:
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
     channel: 6.2/candidate
-    revision: 11
+    revision: 12
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"

--- a/sunbeam-canonical/trilio-dataplane-bundle.yaml
+++ b/sunbeam-canonical/trilio-dataplane-bundle.yaml
@@ -51,7 +51,7 @@ applications:
   trilio-data-mover:
     charm: trilio-data-mover-sunbeam
     channel: 6.2/candidate
-    revision: 9
+    revision: 11
     options:
       triliovault-pkg-source: "deb [trusted=yes] https://apt.fury.io/trilio-maint-6-2 /"
       trilio-version: ""     # Leave empty for latest; or pin to e.g. "6.2.1"


### PR DESCRIPTION
## Summary

- Adds complete T4O deployment for Canonical OpenStack Sunbeam using native Juju ops-framework charms (MicroK8s control plane + machine subordinate for compute nodes)
- Four new charms: `trilio-wlm-k8s`, `trilio-dm-api-k8s`, `trilio-data-mover-sunbeam` (DMS embedded in WLM pod), Horizon plugin via OCI image resource
- Juju bundles for control plane (`openstack` k8s model) and data plane (`openstack-machines` machine model)
- Docker images for WLM, DMAPI, DMS, and Horizon plugin
- Scripts and test suite in `sunbeam-canonical/`

## Key fixes in recent commits

- **DataMover start-limit-hit**: Set `StartLimitIntervalSec=0` in both systemd unit definitions (`triliovault-datamover.service`, `triliovault-dms.service`). Old limit (3 starts/120s) was exhausted by rapid crash cycles during RabbitMQ credential rotation, leaving DataMover permanently down.
- **charmcraft `build-packages: [git]`**: LXD build container lacked `git`; needed for `git+https://` pip dependencies in `requirements.txt`.
- **RabbitMQ username alignment**: Aligned WLM (`workloadmgr`/`workloadmgr`) and DataMover (`dmapi`/`dmapi`) user/vhost names with RHOSO18 6.2 convention.
- **WLM Pebble restart fingerprint**: Added `WLM_CONFIG_FINGERPRINT` env var to force Pebble service restart on config changes.
- **DMS embedded in WLM pod**: Removed standalone `trilio-dms-k8s` charm; DMS now runs as a co-located sidecar container (`trilio-dms`) inside each WLM pod.

## Test plan

- [ ] `juju status` shows all WLM (×3), DMAPI (×3), DataMover (×N compute) units `active/idle`
- [ ] `juju run trilio-wlm-k8s/leader create-cloud-admin-trust` succeeds
- [ ] `juju run trilio-wlm-k8s/leader create-license` succeeds
- [ ] NFS backup target created via `workloadmgr backup-target-create`
- [ ] Snapshot of a running VM reaches `available` status