### PR TITLE
TVAULT-7518: pass --accept-eula to workloadmgr license-create

### DIFF
--- a/juju-charms/charm-trilio-wlm/src/lib/charm/openstack/trilio_wlm.py
+++ b/juju-charms/charm-trilio-wlm/src/lib/charm/openstack/trilio_wlm.py
@@ -332,6 +332,7 @@ class TrilioWLMBaseCharm(charms_openstack.plugins.TrilioVaultCharm):
                 hookenv.config("region"),
                 "license-create",
                 license_file,
+                "--accept-eula",
             ]
         )
         hookenv.leader_set({"licensed": True})

--- a/juju-charms/charm-trilio-wlm/unit_tests/test_lib_charm_openstack_trilio_wlm.py
+++ b/juju-charms/charm-trilio-wlm/unit_tests/test_lib_charm_openstack_trilio_wlm.py
@@ -226,6 +226,7 @@ class TestTrilioWLMCharmStein41LicenseActions(Helper):
                 "TestRegionA",
                 "license-create",
                 "/var/lib/charm/license.lic",
+                "--accept-eula",
             ]
         )
 

--- a/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
+++ b/sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py
@@ -252,11 +252,13 @@ class TrilioWlmK8sCharm(ops.CharmBase):
         (the same credentials the old charm-trilio-wlm's create_license()
         action used) — no password parameter needed.
 
-        'workloadmgr license-create' shows the EULA text via curses and
-        blocks on a real keypress ('y' to accept) before it ever calls the
-        API — this is NOT the same controlling-terminal issue trust-create
-        works around with setsid; it's an actual interactive prompt. Feeding
-        "y\\n" via exec()'s stdin answers that prompt non-interactively.
+        'workloadmgr license-create' normally shows the EULA text via curses
+        and blocks on a real keypress ('y' to accept) before it ever calls
+        the API. The '--accept-eula' flag (added in workloadmgrclient for
+        TVAULT-7518) agrees to the EULA up front and skips that curses block
+        entirely. 'setsid' is still required — that guards against a
+        separate, always-present issue where cmd2 itself opens /dev/tty at
+        startup and fails with "cbreak() returned ERR" under Pebble exec.
         """
         if not self.unit.is_leader():
             event.fail("Run this action on the leader unit only")
@@ -284,12 +286,10 @@ class TrilioWlmK8sCharm(ops.CharmBase):
             "--os-project-domain-name", "service_domain",
             "--os-project-name", identity["service_tenant"],
             "--os-region-name", self.config.get("region", "RegionOne"),
-            "license-create", license_file_path, "-f", "json",
+            "license-create", license_file_path, "-f", "json", "--accept-eula",
         ]
         try:
-            process = container.exec(
-                cmd, environment={"TERM": "xterm"}, stdin="y\n",
-            )
+            process = container.exec(cmd)
             out, err = process.wait_output()
             logger.info("license-create output: %s", out)
             event.set_results({"result": "License applied successfully", "output": out})


### PR DESCRIPTION
## Summary
- `workloadmgr license-create`'s interactive curses EULA prompt needs a controlling terminal; running it from an unattended Juju action (no tty) fails with `cbreak() returned ERR` — the exact failure reported in TVAULT-7518.
- workloadmanager-client PR https://github.com/trilioData/workloadmanager-client/pull/599 (merged) adds a `--accept-eula` flag to `license-create` that agrees to the EULA up front and skips the curses prompt entirely.
- This PR updates both charm-side callers to pass `--accept-eula`:
  - Canonical `charm-trilio-wlm`'s `create_license()` (`juju-charms/charm-trilio-wlm/src/lib/charm/openstack/trilio_wlm.py`) — the code path from the Jira's own repro.
  - Sunbeam `trilio-wlm-k8s`'s `_on_create_license_action` (`sunbeam-canonical/charms/trilio-wlm-k8s/src/charm.py`) — replaces the existing `stdin="y\n"`/`TERM=xterm` workaround for the same curses prompt, now unneeded. `setsid` is kept — that guards a separate, always-present cmd2/tty issue under Pebble exec.
- Updated the corresponding canonical charm unit test to expect `--accept-eula` in the invoked command.

## Test plan
- [ ] Deploy canonical `charm-trilio-wlm`, attach a license resource, run `juju run-action --wait trilio-wlm/leader create-license`, confirm it succeeds without the `cbreak()` error and the unit leaves blocked status.
- [ ] Deploy Sunbeam `trilio-wlm-k8s`, copy a license file into the container, run `juju run trilio-wlm-k8s/leader create-license license-file-path=<path>`, confirm it succeeds.